### PR TITLE
[BE] chore: 테스트 컨테이너 환경 설정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,6 +38,7 @@ out/
 
 ### application ###
 src/main/resources/*.yml
+src/test/resources/*.yml
 
 ### mysql volume ###
 /mysql/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:21-jdk
 
-COPY build/libs/*SNAPSHOT.jar /code-zupzup-server.jar
+COPY build/libs/*SNAPSHOT.jar /feed-zupzup-server.jar
 
-ENTRYPOINT ["java", "-jar", "code-zupzup-server.jar"]
+ENTRYPOINT ["java", "-jar", "feed-zupzup-server.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,14 +37,21 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-task copySecret(type: Copy) {
-    from file('./backend-submodule')
+tasks.register('copySecret', Copy) {
+    from file('./backend-submodule/main')
     include 'application*.yml'
     into 'src/main/resources'
 }
 
-compileJava.dependsOn copySecret
+tasks.register('copySecretTest', Copy) {
+    from file('./backend-submodule/test')
+    include 'application*.yml'
+    into 'src/test/resources'
+}
+
+compileJava.dependsOn copySecret, copySecretTest
 processResources.dependsOn copySecret
+processTestResources.dependsOn copySecretTest
 
 test {
     useJUnitPlatform()

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,11 +30,16 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:mysql'
 }
 
 tasks.register('copySecret', Copy) {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,8 +1,9 @@
 services:
   feed-zupzup-server:
+    container_name: feed-zupzup-server
     build: .
     ports:
-      - 8080:8080
+      - "8080:8080"
     depends_on:
       feed-zupzup-db:
         condition: service_healthy
@@ -16,8 +17,8 @@ services:
     volumes:
       - ./mysql/data:/var/lib/mysql
     ports:
-      - 3306:3306
+      - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping"]
+      test: [ "CMD", "mysqladmin", "ping" ]
       interval: 3s
       retries: 10

--- a/backend/src/test/java/feedzupzup/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/feedzupzup/backend/BackendApplicationTests.java
@@ -1,9 +1,11 @@
 package feedzupzup.backend;
 
+import feedzupzup.backend.config.TestcontainersTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestcontainersTest
 class BackendApplicationTests {
 
     @Test

--- a/backend/src/test/java/feedzupzup/backend/config/DatabaseProperties.java
+++ b/backend/src/test/java/feedzupzup/backend/config/DatabaseProperties.java
@@ -1,0 +1,13 @@
+package feedzupzup.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "test-datasource")
+public record DatabaseProperties(
+        String version,
+        String databaseName,
+        String username,
+        String password
+) {
+
+}

--- a/backend/src/test/java/feedzupzup/backend/config/TestcontainersConfiguration.java
+++ b/backend/src/test/java/feedzupzup/backend/config/TestcontainersConfiguration.java
@@ -1,0 +1,21 @@
+package feedzupzup.backend.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+
+@TestConfiguration
+@EnableConfigurationProperties(DatabaseProperties.class)
+public class TestcontainersConfiguration {
+
+    @Bean
+    @ServiceConnection
+    static MySQLContainer<?> mysqlContainer(final DatabaseProperties databaseProperties) {
+        return new MySQLContainer<>(MySQLContainer.NAME + ":" + databaseProperties.version())
+                .withDatabaseName(databaseProperties.databaseName())
+                .withUsername(databaseProperties.username())
+                .withPassword(databaseProperties.password());
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/config/TestcontainersTest.java
+++ b/backend/src/test/java/feedzupzup/backend/config/TestcontainersTest.java
@@ -1,0 +1,14 @@
+package feedzupzup.backend.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TestcontainersConfiguration.class)
+public @interface TestcontainersTest {
+
+}


### PR DESCRIPTION
## 😉 연관 이슈

#33 

## 🚀 작업 내용

- Testcontainers 의존성을 추가했습니다.
- 테스트 컨테이너 설정 파일을 작성했습니다.
    - `TestcontainersConfiguration`에서 MySQL 컨테이너를 실행합니다.
    - Testcontainers를 사용하는 테스트에는 `TestcontainersTest` 어노테이션을 클래스 레벨에 붙여 사용할 수 있습니다.


**서브 모듈 관련 변경 사항**
https://github.com/feed-zup-zup/backend-submodule/commit/97121b618f24542f360724360bdb7f718b90335d

서브 모듈 내의 yml 파일을 main과 test로 분리했습니다.
main에 있는 .yml 파일은 src/main/resources로, test에 있는 .yml 파일은 src/test/resources로 copy되도록 gralde 스크립트를 변경했습니다.

## 💬 리뷰 중점사항


