### PR TITLE
[BE] feat: User 피드백 페이징 조회 api 구현

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/application/UserFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/UserFeedbackService.java
@@ -2,9 +2,13 @@ package feedzupzup.backend.feedback.application;
 
 import feedzupzup.backend.feedback.domain.FeedBackRepository;
 import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.feedback.domain.FeedbackPage;
 import feedzupzup.backend.feedback.dto.request.CreateFeedbackRequest;
 import feedzupzup.backend.feedback.dto.response.CreateFeedbackResponse;
+import feedzupzup.backend.feedback.dto.response.UserFeedbackListResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,4 +26,10 @@ public class UserFeedbackService {
         return CreateFeedbackResponse.from(savedFeedback);
     }
 
+    public UserFeedbackListResponse getFeedbackPage(final Long placeId, final int size, final Long cursorId) {
+        final Pageable pageable = Pageable.ofSize(size + 1);
+        final List<Feedback> feedbacks = feedBackRepository.findPageByPlaceIdAndCursorIdOrderByDesc(placeId, cursorId, pageable);
+        final FeedbackPage feedbackPage = FeedbackPage.createCursorPage(feedbacks, size);
+        return UserFeedbackListResponse.from(feedbackPage);
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
@@ -24,7 +24,8 @@ public class UserFeedbackController implements UserFeedbackApi {
             final int size,
             final Long cursorId
     ) {
-        throw new UnsupportedOperationException();
+        final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(placeId, size, cursorId);
+        return SuccessResponse.success(HttpStatus.OK, response);
     }
 
     @Override

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/FeedBackRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/FeedBackRepository.java
@@ -14,4 +14,13 @@ public interface FeedBackRepository extends JpaRepository<Feedback, Long> {
             ORDER BY f.id DESC
             """)
     List<Feedback> findPageByCursorIdOrderByDesc(final Long cursorId, final Pageable pageable);
+
+    @Query("""
+            SELECT f
+            FROM Feedback f
+            WHERE f.placeId = :placeId
+            AND (:cursorId IS NULL OR f.id < :cursorId)
+            ORDER BY f.id DESC
+            """)
+    List<Feedback> findPageByPlaceIdAndCursorIdOrderByDesc(final Long placeId, final Long cursorId, final Pageable pageable);
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/dto/response/UserFeedbackListResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/dto/response/UserFeedbackListResponse.java
@@ -1,5 +1,7 @@
 package feedzupzup.backend.feedback.dto.response;
 
+import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.feedback.domain.FeedbackPage;
 import feedzupzup.backend.feedback.domain.ProcessStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -17,8 +19,19 @@ public record UserFeedbackListResponse(
         Long nextCursorId
 ) {
 
+    public static UserFeedbackListResponse from(final FeedbackPage feedbackPage) {
+        final List<UserFeedbackItem> userFeedbackItems = feedbackPage.getFeedbacks().stream()
+                .map(UserFeedbackItem::from)
+                .toList();
+        return new UserFeedbackListResponse(
+                userFeedbackItems,
+                feedbackPage.isHasNext(),
+                feedbackPage.calculateNextCursorId()
+        );
+    }
+
     @Schema(description = "일반 사용자용 피드백 항목")
-    record UserFeedbackItem(
+    public record UserFeedbackItem(
             @Schema(description = "피드백 ID", example = "1")
             Long feedbackId,
 
@@ -38,6 +51,15 @@ public record UserFeedbackListResponse(
             LocalDateTime createdAt
     ) {
 
+        public static UserFeedbackItem from(final Feedback feedback) {
+            return new UserFeedbackItem(
+                    feedback.getId(),
+                    feedback.getContent(),
+                    feedback.getStatus(),
+                    feedback.isSecret(),
+                    false,
+                    feedback.getCreatedAt()
+            );
+        }
     }
-
 }

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/UserFeedbackServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/UserFeedbackServiceTest.java
@@ -3,18 +3,25 @@ package feedzupzup.backend.feedback.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import feedzupzup.backend.feedback.domain.FeedBackRepository;
+import feedzupzup.backend.feedback.domain.Feedback;
 import feedzupzup.backend.feedback.dto.request.CreateFeedbackRequest;
 import feedzupzup.backend.feedback.dto.response.CreateFeedbackResponse;
+import feedzupzup.backend.feedback.dto.response.UserFeedbackListResponse;
+import feedzupzup.backend.feedback.fixture.FeedbackFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class
-UserFeedbackServiceTest extends ServiceIntegrationHelper{
+class UserFeedbackServiceTest extends ServiceIntegrationHelper {
 
     @Autowired
     private UserFeedbackService userFeedbackService;
+
+    @Autowired
+    private FeedBackRepository feedBackRepository;
+
 
     @Nested
     @DisplayName("피드백 생성 테스트")
@@ -37,6 +44,161 @@ UserFeedbackServiceTest extends ServiceIntegrationHelper{
                     () -> assertThat(response.imageUrl()).isEqualTo(request.imageUrl()),
                     () -> assertThat(response.isSecret()).isEqualTo(request.isSecret()),
                     () -> assertThat(response.createdAt()).isNotNull()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백 페이지 조회 테스트")
+    class GetFeedbackPageTest {
+
+        @Test
+        @DisplayName("커서 기반 페이징으로 피드백 목록을 성공적으로 조회한다")
+        void getFeedbackPage_success() {
+            // given
+            final Long placeId = 1L;
+            final Feedback feedback1 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback2 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback3 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback4 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            
+            feedBackRepository.save(feedback1);
+            feedBackRepository.save(feedback2);
+            feedBackRepository.save(feedback3);
+            feedBackRepository.save(feedback4);
+
+            final int size = 2;
+
+            // when
+            final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(placeId, size, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.feedbacks()).hasSize(size),
+                    () -> assertThat(response.hasNext()).isTrue(),
+                    () -> assertThat(response.nextCursorId()).isNotNull()
+            );
+        }
+
+        @Test
+        @DisplayName("마지막 페이지에서 hasNext가 false를 반환한다")
+        void getFeedbackPage_last_page() {
+            // given
+            final Long placeId = 1L;
+            final Feedback feedback1 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback2 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            
+            feedBackRepository.save(feedback1);
+            feedBackRepository.save(feedback2);
+
+            final int size = 5;
+
+            // when
+            final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(placeId, size, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.feedbacks()).hasSize(2),
+                    () -> assertThat(response.hasNext()).isFalse()
+            );
+        }
+
+        @Test
+        @DisplayName("빈 결과에 대해 적절히 처리한다")
+        void getFeedbackPage_empty_result() {
+            // given
+            final Long placeId = 1L;
+            final int size = 10;
+
+            // when
+            final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(placeId, size, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.feedbacks()).isEmpty(),
+                    () -> assertThat(response.hasNext()).isFalse(),
+                    () -> assertThat(response.nextCursorId()).isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("특정 커서 ID로 다음 페이지를 조회한다")
+        void getFeedbackPage_with_cursor() {
+            // given
+            final Long placeId = 1L;
+            final Feedback feedback1 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback2 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback3 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            final Feedback feedback4 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            
+            final Feedback saved1 = feedBackRepository.save(feedback1);
+            final Feedback saved2 = feedBackRepository.save(feedback2);
+            final Feedback saved3 = feedBackRepository.save(feedback3);
+            final Feedback saved4 = feedBackRepository.save(feedback4);
+
+            final int size = 2;
+            final Long cursorId = saved3.getId(); // saved3를 커서로 사용하면 saved2, saved1이 반환됨
+
+            // when
+            final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(placeId, size, cursorId);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.feedbacks()).hasSize(2),
+                    () -> assertThat(response.feedbacks().get(0).feedbackId()).isEqualTo(saved2.getId()), // DESC 정렬이므로 saved2가 먼저
+                    () -> assertThat(response.feedbacks().get(1).feedbackId()).isEqualTo(saved1.getId()),
+                    () -> assertThat(response.hasNext()).isFalse()
+            );
+        }
+
+        @Test
+        @DisplayName("단일 페이지 결과에서 다음 페이지가 없음을 확인한다")
+        void getFeedbackPage_single_page() {
+            // given
+            final Long placeId = 1L;
+            final Feedback feedback = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+            feedBackRepository.save(feedback);
+
+            final int size = 10;
+
+            // when
+            final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(placeId, size, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.feedbacks()).hasSize(1),
+                    () -> assertThat(response.hasNext()).isFalse(),
+                    () -> assertThat(response.nextCursorId()).isNotNull()
+            );
+        }
+
+        @Test
+        @DisplayName("특정 장소의 피드백만 조회한다")
+        void getFeedbackPage_only_specific_place() {
+            // given
+            final Long targetPlaceId = 1L;
+            final Long otherPlaceId = 2L;
+            
+            final Feedback targetFeedback1 = FeedbackFixture.createFeedbackWithPlaceId(targetPlaceId);
+            final Feedback targetFeedback2 = FeedbackFixture.createFeedbackWithPlaceId(targetPlaceId);
+            final Feedback otherFeedback = FeedbackFixture.createFeedbackWithPlaceId(otherPlaceId);
+            
+            feedBackRepository.save(targetFeedback1);
+            feedBackRepository.save(targetFeedback2);
+            feedBackRepository.save(otherFeedback);
+
+            final int size = 10;
+
+            // when
+            final UserFeedbackListResponse response = userFeedbackService.getFeedbackPage(targetPlaceId, size, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.feedbacks()).hasSize(2),
+                    () -> assertThat(response.feedbacks())
+                            .extracting(UserFeedbackListResponse.UserFeedbackItem::feedbackId)
+                            .doesNotContain(otherFeedback.getId()),
+                    () -> assertThat(response.hasNext()).isFalse()
             );
         }
     }

--- a/backend/src/test/java/feedzupzup/backend/feedback/controller/UserFeedbackControllerE2ETest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/controller/UserFeedbackControllerE2ETest.java
@@ -2,20 +2,156 @@ package feedzupzup.backend.feedback.controller;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
+import feedzupzup.backend.feedback.domain.FeedBackRepository;
+import feedzupzup.backend.feedback.domain.Feedback;
 import feedzupzup.backend.feedback.dto.request.CreateFeedbackRequest;
+import feedzupzup.backend.feedback.fixture.FeedbackFixture;
 import feedzupzup.backend.feedback.fixture.FeedbackRequestFixture;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 class UserFeedbackControllerE2ETest extends E2EHelper {
 
+    @Autowired
+    private FeedBackRepository feedBackRepository;
+
+    @Test
+    @DisplayName("사용자가 특정 장소의 피드백 목록을 성공적으로 조회한다")
+    void user_get_feedbacks_success() {
+        // given
+        final Long placeId = 1L;
+        final Feedback feedback1 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+        final Feedback feedback2 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+        final Feedback feedback3 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+
+        feedBackRepository.save(feedback1);
+        feedBackRepository.save(feedback2);
+        feedBackRepository.save(feedback3);
+
+        // when & then
+        given()
+                .log().all()
+                .queryParam("size", 10)
+                .when()
+                .get("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(200))
+                .body("message", equalTo("OK"))
+                .body("data.feedbacks", hasSize(3))
+                .body("data.hasNext", equalTo(false))
+                .body("data.nextCursorId", notNullValue());
+    }
+
+    @Test
+    @DisplayName("사용자가 커서 기반 페이징으로 피드백 목록을 조회한다")
+    void user_get_feedbacks_with_cursor_pagination() {
+        // given
+        final Long placeId = 1L;
+        final Feedback feedback1 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+        final Feedback feedback2 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+        final Feedback feedback3 = FeedbackFixture.createFeedbackWithPlaceId(placeId);
+
+        feedBackRepository.save(feedback1);
+        feedBackRepository.save(feedback2);
+        feedBackRepository.save(feedback3);
+
+        // when - 첫 번째 페이지 조회
+        final Long firstPageCursor = given()
+                .log().all()
+                .queryParam("size", 2)
+                .when()
+                .get("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(200))
+                .body("message", equalTo("OK"))
+                .body("data.feedbacks", hasSize(2))
+                .body("data.hasNext", equalTo(true))
+                .extract()
+                .jsonPath()
+                .getLong("data.nextCursorId");
+
+        // when - 두 번째 페이지 조회
+        given()
+                .log().all()
+                .queryParam("size", 2)
+                .queryParam("cursorId", firstPageCursor)
+                .when()
+                .get("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(200))
+                .body("message", equalTo("OK"))
+                .body("data.feedbacks", hasSize(1))
+                .body("data.hasNext", equalTo(false));
+    }
+
+    @Test
+    @DisplayName("사용자가 빈 피드백 목록을 조회한다")
+    void user_get_empty_feedbacks() {
+        // given
+        final Long placeId = 999L; // 피드백이 없는 장소
+
+        // when & then
+        given()
+                .log().all()
+                .queryParam("size", 10)
+                .when()
+                .get("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(200))
+                .body("message", equalTo("OK"))
+                .body("data.feedbacks", hasSize(0))
+                .body("data.hasNext", equalTo(false))
+                .body("data.nextCursorId", equalTo(null));
+    }
+
+    @Test
+    @DisplayName("사용자가 특정 장소의 피드백만 조회한다 (다른 장소 피드백 제외)")
+    void user_get_feedbacks_only_for_specific_place() {
+        // given
+        final Long targetPlaceId = 1L;
+        final Long otherPlaceId = 2L;
+        
+        final Feedback targetFeedback1 = FeedbackFixture.createFeedbackWithPlaceId(targetPlaceId);
+        final Feedback targetFeedback2 = FeedbackFixture.createFeedbackWithPlaceId(targetPlaceId);
+        final Feedback otherFeedback = FeedbackFixture.createFeedbackWithPlaceId(otherPlaceId);
+
+        feedBackRepository.save(targetFeedback1);
+        feedBackRepository.save(targetFeedback2);
+        feedBackRepository.save(otherFeedback);
+
+        // when & then
+        given()
+                .log().all()
+                .queryParam("size", 10)
+                .when()
+                .get("/places/{placeId}/feedbacks", targetPlaceId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(200))
+                .body("message", equalTo("OK"))
+                .body("data.feedbacks", hasSize(2)) // 대상 장소의 피드백 2개만
+                .body("data.hasNext", equalTo(false));
+    }
+
     @Test
     @DisplayName("피드백을 성공적으로 생성한다")
-    void create_secret_feedback_success() {
+    void create_feedback_success() {
         // given
         final Long placeId = 1L;
         final CreateFeedbackRequest request = FeedbackRequestFixture.createRequestWithContent("피드백");
@@ -36,5 +172,68 @@ class UserFeedbackControllerE2ETest extends E2EHelper {
                 .body("data.content", equalTo("피드백"))
                 .body("data.isSecret", equalTo(false))
                 .body("data.createdAt", notNullValue());
+    }
+
+    @Test
+    @DisplayName("사용자가 비밀 피드백을 성공적으로 생성한다")
+    void user_create_secret_feedback_success() {
+        // given
+        final Long placeId = 1L;
+        final CreateFeedbackRequest request = new CreateFeedbackRequest("비밀 피드백입니다", "이미지URL", true);
+
+        // when & then
+        given()
+                .log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(201))
+                .body("message", equalTo("CREATED"))
+                .body("data.feedbackId", notNullValue())
+                .body("data.content", equalTo("비밀 피드백입니다"))
+                .body("data.imageUrl", equalTo("이미지URL"))
+                .body("data.isSecret", equalTo(true))
+                .body("data.createdAt", notNullValue());
+    }
+
+    @Test
+    @DisplayName("사용자가 새로 생성한 피드백이 목록에 나타난다")
+    void user_create_feedback_appears_in_list() {
+        // given
+        final Long placeId = 1L;
+        final CreateFeedbackRequest request = new CreateFeedbackRequest("새 피드백", "new.jpg", false);
+
+        // when - 피드백 생성
+        final Long createdFeedbackId = given()
+                .log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .jsonPath()
+                .getLong("data.feedbackId");
+
+        // then - 목록에서 확인
+        given()
+                .log().all()
+                .queryParam("size", 10)
+                .when()
+                .get("/places/{placeId}/feedbacks", placeId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(ContentType.JSON)
+                .body("status", equalTo(200))
+                .body("message", equalTo("OK"))
+                .body("data.feedbacks", hasSize(greaterThan(0)))
+                .body("data.feedbacks[0].feedbackId", equalTo(createdFeedbackId.intValue()))
+                .body("data.feedbacks[0].content", equalTo("새 피드백"))
+                .body("data.feedbacks[0].isSecret", equalTo(false));
     }
 }


### PR DESCRIPTION
## 😉 연관 이슈
#26 

## 🚀 작업 내용
유저 피드백 페이지네이션 구현했어요.
어드민과 로직은 동일하고 응답 dto에 url만 빠졌습니다~

## 💬 리뷰 중점사항
