### PR TITLE
[FE] setting: emotion/react에 따른 스토리북 세팅

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,5 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
-import path from  'path';
+import path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -14,7 +14,6 @@ const config: StorybookConfig = {
     options: {},
   },
   webpackFinal: async (config) => {
-    // 기존 alias 설정
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
@@ -22,9 +21,7 @@ const config: StorybookConfig = {
       };
     }
 
-    // Emotion CSS prop 지원을 위한 babel 설정
     if (config.module?.rules) {
-      // 기존 JS/JSX 규칙 수정
       const jsRule = config.module.rules.find((rule) => {
         if (typeof rule === 'object' && rule && 'test' in rule) {
           return rule.test?.toString().includes('jsx?');
@@ -54,9 +51,12 @@ const config: StorybookConfig = {
           'options' in babelLoader
         ) {
           babelLoader.options = {
-            ...babelLoader.options,
+            ...(babelLoader.options as Record<string, unknown>),
             presets: [
-              ...(Array.isArray(babelLoader.options?.presets)
+              ...(typeof babelLoader.options === 'object' &&
+              babelLoader.options &&
+              'presets' in babelLoader.options &&
+              Array.isArray(babelLoader.options.presets)
                 ? babelLoader.options.presets
                 : []),
               '@emotion/babel-preset-css-prop',
@@ -65,7 +65,6 @@ const config: StorybookConfig = {
         }
       }
 
-      // TypeScript 파일을 위한 새로운 규칙 추가
       config.module.rules.push({
         test: /\.(ts|tsx)$/,
         use: [

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,18 +1,94 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
+import path from  'path';
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@storybook/addon-webpack5-compiler-swc',
+    '@storybook/addon-docs',
+    '@storybook/addon-onboarding',
+    '@storybook/addon-themes',
   ],
-  "addons": [
-    "@storybook/addon-webpack5-compiler-swc",
-    "@storybook/addon-docs",
-    "@storybook/addon-onboarding"
-  ],
-  "framework": {
-    "name": "@storybook/react-webpack5",
-    "options": {}
-  }
+  framework: {
+    name: '@storybook/react-webpack5',
+    options: {},
+  },
+  webpackFinal: async (config) => {
+    // 기존 alias 설정
+    if (config.resolve) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@': path.resolve(__dirname, '../src'),
+      };
+    }
+
+    // Emotion CSS prop 지원을 위한 babel 설정
+    if (config.module?.rules) {
+      // 기존 JS/JSX 규칙 수정
+      const jsRule = config.module.rules.find((rule) => {
+        if (typeof rule === 'object' && rule && 'test' in rule) {
+          return rule.test?.toString().includes('jsx?');
+        }
+        return false;
+      });
+
+      if (jsRule && typeof jsRule === 'object' && jsRule && 'use' in jsRule) {
+        const babelLoader = Array.isArray(jsRule.use)
+          ? jsRule.use.find(
+              (loader) =>
+                typeof loader === 'object' &&
+                loader &&
+                'loader' in loader &&
+                loader.loader?.includes('babel-loader')
+            )
+          : typeof jsRule.use === 'object' &&
+              jsRule.use &&
+              'loader' in jsRule.use &&
+              jsRule.use.loader?.includes('babel-loader')
+            ? jsRule.use
+            : null;
+
+        if (
+          babelLoader &&
+          typeof babelLoader === 'object' &&
+          'options' in babelLoader
+        ) {
+          babelLoader.options = {
+            ...babelLoader.options,
+            presets: [
+              ...(Array.isArray(babelLoader.options?.presets)
+                ? babelLoader.options.presets
+                : []),
+              '@emotion/babel-preset-css-prop',
+            ],
+          };
+        }
+      }
+
+      // TypeScript 파일을 위한 새로운 규칙 추가
+      config.module.rules.push({
+        test: /\.(ts|tsx)$/,
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              presets: [
+                [
+                  '@babel/preset-react',
+                  { runtime: 'automatic', importSource: '@emotion/react' },
+                ],
+                '@babel/preset-typescript',
+                '@emotion/babel-preset-css-prop',
+              ],
+              plugins: ['@emotion/babel-plugin'],
+            },
+          },
+        ],
+      });
+    }
+
+    return config;
+  },
 };
+
 export default config;

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -7,7 +7,6 @@ const config: StorybookConfig = {
     '@storybook/addon-webpack5-compiler-swc',
     '@storybook/addon-docs',
     '@storybook/addon-onboarding',
-    '@storybook/addon-themes',
   ],
   framework: {
     name: '@storybook/react-webpack5',
@@ -22,49 +21,6 @@ const config: StorybookConfig = {
     }
 
     if (config.module?.rules) {
-      const jsRule = config.module.rules.find((rule) => {
-        if (typeof rule === 'object' && rule && 'test' in rule) {
-          return rule.test?.toString().includes('jsx?');
-        }
-        return false;
-      });
-
-      if (jsRule && typeof jsRule === 'object' && jsRule && 'use' in jsRule) {
-        const babelLoader = Array.isArray(jsRule.use)
-          ? jsRule.use.find(
-              (loader) =>
-                typeof loader === 'object' &&
-                loader &&
-                'loader' in loader &&
-                loader.loader?.includes('babel-loader')
-            )
-          : typeof jsRule.use === 'object' &&
-              jsRule.use &&
-              'loader' in jsRule.use &&
-              jsRule.use.loader?.includes('babel-loader')
-            ? jsRule.use
-            : null;
-
-        if (
-          babelLoader &&
-          typeof babelLoader === 'object' &&
-          'options' in babelLoader
-        ) {
-          babelLoader.options = {
-            ...(babelLoader.options as Record<string, unknown>),
-            presets: [
-              ...(typeof babelLoader.options === 'object' &&
-              babelLoader.options &&
-              'presets' in babelLoader.options &&
-              Array.isArray(babelLoader.options.presets)
-                ? babelLoader.options.presets
-                : []),
-              '@emotion/babel-preset-css-prop',
-            ],
-          };
-        }
-      }
-
       config.module.rules.push({
         test: /\.(ts|tsx)$/,
         use: [
@@ -79,7 +35,6 @@ const config: StorybookConfig = {
                 '@babel/preset-typescript',
                 '@emotion/babel-preset-css-prop',
               ],
-              plugins: ['@emotion/babel-plugin'],
             },
           },
         ],

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,11 +1,11 @@
-import type { Preview } from '@storybook/react-webpack5'
+import type { Preview } from '@storybook/react-webpack5';
 
 const preview: Preview = {
   parameters: {
     controls: {
       matchers: {
-       color: /(background|color)$/i,
-       date: /Date$/i,
+        color: /(background|color)$/i,
+        date: /Date$/i,
       },
     },
   },

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,5 +1,5 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
-import storybook from "eslint-plugin-storybook";
+import storybook from 'eslint-plugin-storybook';
 
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
@@ -8,35 +8,42 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import prettierPlugin from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
 
-export default [js.configs.recommended, ...tseslint.configs.recommended, prettierConfig, {
-  files: ['**/*.ts', '**/*.tsx'],
-  plugins: {
-    '@typescript-eslint': tseslint.plugin,
-    react,
-    'react-hooks': reactHooks,
-    prettier: prettierPlugin,
-  },
-  languageOptions: {
-    parser: tseslint.parser,
-    parserOptions: {
-      project: './tsconfig.json',
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      ecmaFeatures: {
-        jsx: true,
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettierConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['.storybook/**/*'],
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      react,
+      'react-hooks': reactHooks,
+      prettier: prettierPlugin,
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: './tsconfig.json',
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
       },
     },
+    rules: {
+      'react/react-in-jsx-scope': 'off',
+      quotes: ['error', 'single', { avoidEscape: true }],
+      'prettier/prettier': [
+        'error',
+        {
+          jsxSingleQuote: true,
+          singleQuote: true,
+          semi: true,
+        },
+      ],
+    },
   },
-  rules: {
-    'react/react-in-jsx-scope': 'off',
-    quotes: ['error', 'single', { avoidEscape: true }],
-    'prettier/prettier': [
-      'error',
-      {
-        jsxSingleQuote: true,
-        singleQuote: true,
-        semi: true,
-      },
-    ],
-  },
-}, ...storybook.configs["flat/recommended"]];
+  ...storybook.configs['flat/recommended'],
+];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@eslint/js": "^9.30.1",
         "@storybook/addon-docs": "^9.0.17",
         "@storybook/addon-onboarding": "^9.0.17",
+        "@storybook/addon-themes": "^9.0.17",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
         "@storybook/react-webpack5": "^9.0.17",
         "@stylelint/postcss-css-in-js": "^0.38.0",
@@ -3966,6 +3967,23 @@
       "integrity": "sha512-WoZZ8d58gP6uBu6OJ2K1GjBSM4+Kcr0I9lo0z3convzYqxrhfUm9pNEwVm57KCbVVyBbIKmevddCsSFoPC5u6Q==",
       "dev": true,
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^9.0.17"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-9.0.17.tgz",
+      "integrity": "sha512-qQCoWig+wPVVuiibk8AuUUH/hS9hbLFt2IdjpiCIObAjStqSQMosr/1b95FcxppBCEa8uTltEkGdxQPdpdVZEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@eslint/js": "^9.30.1",
     "@storybook/addon-docs": "^9.0.17",
     "@storybook/addon-onboarding": "^9.0.17",
+    "@storybook/addon-themes": "^9.0.17",
     "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
     "@storybook/react-webpack5": "^9.0.17",
     "@stylelint/postcss-css-in-js": "^0.38.0",

--- a/frontend/src/components/BasicButton/BasicButton.stories.tsx
+++ b/frontend/src/components/BasicButton/BasicButton.stories.tsx
@@ -3,7 +3,6 @@ import { ThemeProvider } from '@emotion/react';
 import { theme } from '@/theme';
 import BasicButton from './BasicButton';
 import Plus from '@/components/icons/Plus';
-import Profile from '@/components/icons/Profile';
 
 const meta: Meta<typeof BasicButton> = {
   title: 'Components/BasicButton',
@@ -61,14 +60,6 @@ export const WithIcon: Story = {
   },
 };
 
-export const WithProfileIcon: Story = {
-  args: {
-    children: '프로필',
-    icon: <Profile />,
-    variant: 'secondary',
-  },
-};
-
 export const CustomWidth: Story = {
   args: {
     children: '커스텀 너비',
@@ -81,13 +72,5 @@ export const LongText: Story = {
   args: {
     children: '매우 긴 버튼 텍스트입니다',
     variant: 'primary',
-  },
-};
-
-export const Disabled: Story = {
-  args: {
-    children: '비활성화 버튼',
-    variant: 'primary',
-    disabled: true,
   },
 };

--- a/frontend/src/components/BasicButton/BasicButton.stories.tsx
+++ b/frontend/src/components/BasicButton/BasicButton.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { ThemeProvider } from '@emotion/react';
+import { theme } from '@/theme';
+import BasicButton from './BasicButton';
+import Plus from '@/components/icons/Plus';
+import Profile from '@/components/icons/Profile';
+
+const meta: Meta<typeof BasicButton> = {
+  title: 'Components/BasicButton',
+  component: BasicButton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    width: {
+      control: 'text',
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+    },
+    onClick: {
+      action: 'clicked',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    children: '기본 버튼',
+    variant: 'primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    children: '보조 버튼',
+    variant: 'secondary',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    children: '아이콘 버튼',
+    icon: <Plus />,
+    variant: 'primary',
+  },
+};
+
+export const WithProfileIcon: Story = {
+  args: {
+    children: '프로필',
+    icon: <Profile />,
+    variant: 'secondary',
+  },
+};
+
+export const CustomWidth: Story = {
+  args: {
+    children: '커스텀 너비',
+    width: 200,
+    variant: 'primary',
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    children: '매우 긴 버튼 텍스트입니다',
+    variant: 'primary',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: '비활성화 버튼',
+    variant: 'primary',
+    disabled: true,
+  },
+};

--- a/frontend/src/components/BasicButton/BasicButton.styles.ts
+++ b/frontend/src/components/BasicButton/BasicButton.styles.ts
@@ -43,9 +43,10 @@ export const basicButtonText = (
 ) => css`
   margin: 0;
   ${theme.typography.inter.small};
+
   color: ${variant === 'primary'
     ? theme.colors.black[100]
-    : theme.colors.darkGray[100]};
+    : theme.colors.white[100]};
 `;
 
 export const basicButtonIcon = css`

--- a/frontend/src/components/BasicButton/BasicButton.styles.ts
+++ b/frontend/src/components/BasicButton/BasicButton.styles.ts
@@ -17,9 +17,9 @@ export const basicButton = (
     ? theme.colors.yellow[200]
     : theme.colors.white[100]} !important;
   border: ${variant === 'secondary'
-    ? `1px solid ${theme.colors.darkGray[100]}`
+    ? `1px solid ${theme.colors.gray[200]}`
     : 'none'};
-  border-radius: 14.5px;
+  border-radius: 14px;
   cursor: pointer;
   transition: opacity 0.2s ease;
 
@@ -46,7 +46,7 @@ export const basicButtonText = (
 
   color: ${variant === 'primary'
     ? theme.colors.black[100]
-    : theme.colors.white[100]};
+    : theme.colors.darkGray[100]};
 `;
 
 export const basicButtonIcon = css`

--- a/frontend/src/components/GhostButton/GhostButton.styles.ts
+++ b/frontend/src/components/GhostButton/GhostButton.styles.ts
@@ -4,15 +4,16 @@ import { Theme } from '@/theme';
 
 export const ghostButton = (theme: Theme) => css`
   ${theme.typography.inter.caption};
-  background-color: ${colors.white[100]}33;
-  border: 1px solid ${colors.white[100]}33;
-  border-radius: 16px;
-  cursor: pointer;
+
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
   color: ${colors.white[100]};
+  background-color: ${colors.white[100]}33;
+  border: 1px solid ${colors.white[100]}33;
+  border-radius: 16px;
+  cursor: pointer;
   transition: opacity 0.2s ease;
 
   &:hover {

--- a/frontend/src/components/GhostButton/GhostButton.styles.ts
+++ b/frontend/src/components/GhostButton/GhostButton.styles.ts
@@ -5,15 +5,15 @@ import { Theme } from '@/theme';
 export const ghostButton = (theme: Theme) => css`
   ${theme.typography.inter.caption};
 
+  background-color: ${colors.white[100]}33;
+  border: 1px solid ${colors.white[100]}33;
+  border-radius: 16px;
+  cursor: pointer;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
   color: ${colors.white[100]};
-  background-color: ${colors.white[100]}33;
-  border: 1px solid ${colors.white[100]}33;
-  border-radius: 16px;
-  cursor: pointer;
   transition: opacity 0.2s ease;
 
   &:hover {

--- a/frontend/src/domains/user/home/components/Hero/Hero.styles.ts
+++ b/frontend/src/domains/user/home/components/Hero/Hero.styles.ts
@@ -3,88 +3,91 @@ import heroBackground from '@/assets/images/hero-background.png';
 import { Theme } from '@/theme';
 
 export const hero = (theme: Theme) => css`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  min-height: 100vh;
+  margin: -14px -14px 0;
+  text-align: center;
+  color: white;
   background-image:
     linear-gradient(${theme.colors.black[100]}59, ${theme.colors.black[100]}59),
     url(${heroBackground});
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-  color: white;
-  text-align: center;
-  margin: -14px -14px 0 -14px;
-  box-sizing: border-box;
 `;
 
 export const heroHeader = (theme: Theme) => css`
-  width: 100%;
-  height: 56px;
-  background-color: ${theme.colors.black[100]}33;
-  margin: 0 -20px 0 -20px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  width: 100%;
+  height: 56px;
+  margin: 0 -20px;
   padding: 0 14px;
+  background-color: ${theme.colors.black[100]}33;
 `;
 
 export const heroContent = css`
-  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: 0 8px 20px 8px;
   width: 100%;
+  margin: 0 8px 20px;
   padding: 0 20px;
 `;
 
 export const heroHr = (theme: Theme) => css`
   width: 56px;
   height: 2px;
+  margin: 0 0 14px;
   background-color: ${theme.colors.yellow[200]};
   border: none;
-  margin: 0 0 14px 0;
 `;
 
 export const heroTitle = (theme: Theme) => css`
   ${theme.typography.inter.small};
+
+  margin: 0 0 14px;
   color: ${theme.colors.yellow[200]};
-  margin: 0 0 14px 0;
 `;
 
 export const heroLogo = css`
   width: 112px;
   height: auto;
-  margin: 0 0 16px 0;
+  margin: 0 0 16px;
 `;
 
 export const heroDescription = (theme: Theme) => css`
   ${theme.typography.inter.small};
-  color: ${theme.colors.white[100]};
-  margin: 0 0 24px 0;
-  text-align: left;
+
+  margin: 0 0 24px;
   line-height: 1.5;
+  text-align: left;
+  color: ${theme.colors.white[100]};
 `;
 
 export const catAnimation = css`
   position: absolute;
+  right: 24px;
+  bottom: 32px;
+  z-index: 1;
   width: 60px;
   height: auto;
-  bottom: 32px;
-  right: 24px;
-  animation: catMove 3s ease-in-out infinite;
-  z-index: 1;
+  animation: cat-move 3s ease-in-out infinite;
 
-  @keyframes catMove {
+  @keyframes cat-move {
     0% {
       transform: translateX(0);
     }
+
     50% {
       transform: translateX(-100px);
     }
+
     100% {
       transform: translateX(0);
     }

--- a/frontend/src/domains/user/home/components/Hero/Hero.styles.ts
+++ b/frontend/src/domains/user/home/components/Hero/Hero.styles.ts
@@ -7,7 +7,7 @@ export const hero = (theme: Theme) => css`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  box-sizing: border-box;
+box-sizing: border-box;
   min-height: 100vh;
   margin: -14px -14px 0;
   text-align: center;
@@ -51,8 +51,8 @@ export const heroHr = (theme: Theme) => css`
 export const heroTitle = (theme: Theme) => css`
   ${theme.typography.inter.small};
 
-  margin: 0 0 14px;
   color: ${theme.colors.yellow[200]};
+  margin: 0 0 14px;
 `;
 
 export const heroLogo = css`
@@ -64,10 +64,10 @@ export const heroLogo = css`
 export const heroDescription = (theme: Theme) => css`
   ${theme.typography.inter.small};
 
-  margin: 0 0 24px;
-  line-height: 1.5;
-  text-align: left;
   color: ${theme.colors.white[100]};
+  margin: 0 0 24px;
+  text-align: left;
+  line-height: 1.5;
 `;
 
 export const catAnimation = css`
@@ -77,9 +77,9 @@ export const catAnimation = css`
   z-index: 1;
   width: 60px;
   height: auto;
-  animation: cat-move 3s ease-in-out infinite;
+  animation: catMove 3s ease-in-out infinite;
 
-  @keyframes cat-move {
+  @keyframes catMove {
     0% {
       transform: translateX(0);
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -30,5 +30,5 @@
     "noEmit": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src", "types", "cypress"]
+  "include": ["src", "types", "cypress", ".storybook"]
 }


### PR DESCRIPTION
## 😉 연관 이슈
#93 

## 🚀 작업 내용
- frontend/.storybook/main.ts 세팅 수정
- BasicButton 스타일 일부 수정
- BasicButton story 수정
- ghostbutton이나 hero는 스타일 세팅이 먹혀서 파일 변경이 일어났고, 내용 자체는 변경되지 않았습니다.


### TSX 파일 전용 Babel 규칙 추가
아래부분이 추가됐는데요, 이전에는 css prop를 일반 HTML속성으로 처리하느라 스타일이 무시됐던거더라구요.

빌드 타임에 css prop을 실제 CSS 클래스로 변환하는 등의 로직을 거치니 해결된것같습니다.
```ts
config.module.rules.push({
  test: /\.(ts|tsx)$/,  
  use: [{
    loader: require.resolve('babel-loader'),
    options: {
      presets: [
        ['@babel/preset-react', { 
          runtime: 'automatic', 
          importSource: '@emotion/react'
        }],
        '@babel/preset-typescript',   
        '@emotion/babel-preset-css-prop' 
      ],
    },
  }],
});
```



## 💬 리뷰 중점사항
