### PR TITLE
[FE] setting: 웹팩 사용에 따른 .env 사용 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.14.0",
+        "dotenv": "^17.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.7.0"
@@ -8480,6 +8481,18 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   "description": "",
   "dependencies": {
     "@emotion/react": "^11.14.0",
+    "dotenv": "^17.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.0"

--- a/frontend/webpack/webpack.common.js
+++ b/frontend/webpack/webpack.common.js
@@ -1,10 +1,14 @@
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import webpack from 'webpack';
+import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+dotenv.config();
 
 export default {
   entry: './src/index.tsx',
@@ -48,6 +52,9 @@ export default {
   plugins: [
     new HtmlWebpackPlugin({
       template: './public/index.html',
+    }),
+    new webpack.DefinePlugin({
+      'process.env': JSON.stringify(process.env),
     }),
   ],
 };


### PR DESCRIPTION
## 😉 연관 이슈
#124 

## 🚀 작업 내용
- 환경변수 사용할수있게 세팅 진행했습니다.

### 사용방법
.env 파일을 바로 front 폴더 하위에 만들어서 (frontend/.env)

```
REACT_APP_NOTION_TOKEN=hihellohihello
```

UserPage쪽에  아래같은 내용 넣어서 테스팅 해보시면 됩니다. 이후에 추가할거 생기면 .env파일에 내용넣어서 추가해주시고 따로 공유해주시면 되겠습니당!

```
console.log('로드된 환경변수:', process.env.REACT_APP_NOTION_TOKEN);
```

## 💬 리뷰 중점사항
