### PR TITLE
[BE] fix: springboot version과 openapi version 호환성 이슈 해결 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## 😉 연관 이슈
closes #132 

## 🚀 작업 내용
Spring Boot 3.4.0 부터 ControllerAdviceBean 클래스의 생성자 시그니처가 변경되었는데, 기존 SpringDoc 버전들(2.5.0, 2.6.0, 2.7.0)은 여전히 이전 시그니처를 사용하고 있어서 NoSuchMethodError가 발생 
```
java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)'
```

SpringDoc 최신 버전(2025.07.22 기준) 2.8.9으로 변경