### PR TITLE
[FE] refactor: baseURL apiClient로 이동

### DIFF
--- a/frontend/src/apis/apiClient.ts
+++ b/frontend/src/apis/apiClient.ts
@@ -91,8 +91,10 @@ async function baseClient<Response, RequestBody>({
     'Content-type': 'application/json',
   };
 
+  const fullURL = `${process.env.BASE_URL}${URI}`;
+
   try {
-    const response = await fetchWithTimeout(URI, {
+    const response = await fetchWithTimeout(fullURL, {
       method,
       headers,
       body: body ? JSON.stringify(body) : null,

--- a/frontend/src/hooks/useInfinityScroll.ts
+++ b/frontend/src/hooks/useInfinityScroll.ts
@@ -39,7 +39,7 @@ export default function useInfinityScroll<
 
     try {
       const response = await apiClient.get<{ data: ResponseData }>(
-        `${process.env.BASE_URL}${url}?${query.toString()}`
+        `${url}?${query.toString()}`
       );
 
       if (!response) return;


### PR DESCRIPTION
## 😉 연관 이슈
close #174 

## 🚀 작업 내용
baseURL을 apiClient로 이동

이제 `apiClient.get('url')` 에서 url 부분은 `/api~~` 만 작성하면 됩니다!
ex)  url: '/api/admin/places/1/feedbacks',
