### PR TITLE
[BE] chore: 환경별 logback 설정 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "be/develop" ]
 
+env:
+  TZ: Asia/Seoul
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -42,3 +42,6 @@ src/test/resources/*.yml
 
 ### mysql volume ###
 /mysql/
+
+### alloy ###
+config.alloy

--- a/backend/src/main/java/feedzupzup/backend/global/api/GlobalController.java
+++ b/backend/src/main/java/feedzupzup/backend/global/api/GlobalController.java
@@ -1,0 +1,18 @@
+package feedzupzup.backend.global.api;
+
+import feedzupzup.backend.global.response.SuccessResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class GlobalController {
+
+    @GetMapping("/health-check")
+    public SuccessResponse<String> healthCheck() {
+        log.info("Health check successfully");
+        return SuccessResponse.success(HttpStatus.OK, "Health check successfully");
+    }
+}

--- a/backend/src/main/resources/logback/logback-dev.xml
+++ b/backend/src/main/resources/logback/logback-dev.xml
@@ -1,0 +1,108 @@
+<configuration>
+  <property name="FILE_LOG_PATTERN"
+    value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] [dev] [%thread] %-5level [%C.%M:%L] - %msg%n"/>
+  <property name="LOGS_ROOT_PATH" value="/var/log/spring"/>
+
+  <!-- TRACE 로그 설정 -->
+  <appender name="TRACE_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/trace/trace.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/trace/trace-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>7</maxHistory>
+      <totalSizeCap>500MB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>TRACE</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <!-- DEBUG 로그 설정 -->
+  <appender name="DEBUG_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/debug/debug.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/debug/debug-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>14</maxHistory>
+      <totalSizeCap>800MB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>DEBUG</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <!-- INFO 로그 설정 -->
+  <appender name="INFO_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/info/info.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>INFO</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <!-- WARN 로그 설정 -->
+  <appender name="WARN_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/warn/warn.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>WARN</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <!-- ERROR 로그 설정 -->
+  <appender name="ERROR_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/error/error.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>90</maxHistory>
+      <totalSizeCap>2GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="TRACE_LOG_FILE"/>
+    <appender-ref ref="DEBUG_LOG_FILE"/>
+    <appender-ref ref="INFO_LOG_FILE"/>
+    <appender-ref ref="WARN_LOG_FILE"/>
+    <appender-ref ref="ERROR_LOG_FILE"/>
+  </root>
+</configuration>

--- a/backend/src/main/resources/logback/logback-dev.xml
+++ b/backend/src/main/resources/logback/logback-dev.xml
@@ -9,7 +9,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
       <fileNamePattern>${LOGS_ROOT_PATH}/trace/trace-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>10MB</maxFileSize>
-      <maxHistory>7</maxHistory>
+      <maxHistory>14</maxHistory>
       <totalSizeCap>500MB</totalSizeCap>
     </rollingPolicy>
     <encoder>

--- a/backend/src/main/resources/logback/logback-dev.xml
+++ b/backend/src/main/resources/logback/logback-dev.xml
@@ -3,106 +3,19 @@
     value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] [dev] [%thread] %-5level [%C.%M:%L] - %msg%n"/>
   <property name="LOGS_ROOT_PATH" value="/var/log/spring"/>
 
-  <!-- TRACE 로그 설정 -->
-  <appender name="TRACE_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/trace/trace.log</file>
+  <appender name="APP_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/app.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/trace/trace-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>14</maxHistory>
-      <totalSizeCap>500MB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>TRACE</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-  </appender>
-
-  <!-- DEBUG 로그 설정 -->
-  <appender name="DEBUG_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/debug/debug.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/debug/debug-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>14</maxHistory>
-      <totalSizeCap>800MB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>DEBUG</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-  </appender>
-
-  <!-- INFO 로그 설정 -->
-  <appender name="INFO_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/info/info.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${LOGS_ROOT_PATH}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>10MB</maxFileSize>
       <maxHistory>30</maxHistory>
-      <totalSizeCap>1GB</totalSizeCap>
     </rollingPolicy>
     <encoder>
       <pattern>${FILE_LOG_PATTERN}</pattern>
     </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>INFO</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-  </appender>
-
-  <!-- WARN 로그 설정 -->
-  <appender name="WARN_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/warn/warn.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>30</maxHistory>
-      <totalSizeCap>1GB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>WARN</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-  </appender>
-
-  <!-- ERROR 로그 설정 -->
-  <appender name="ERROR_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/error/error.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>90</maxHistory>
-      <totalSizeCap>2GB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>ERROR</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
   </appender>
 
   <root level="info">
-    <appender-ref ref="TRACE_LOG_FILE"/>
-    <appender-ref ref="DEBUG_LOG_FILE"/>
-    <appender-ref ref="INFO_LOG_FILE"/>
-    <appender-ref ref="WARN_LOG_FILE"/>
-    <appender-ref ref="ERROR_LOG_FILE"/>
+    <appender-ref ref="APP_LOG_FILE"/>
   </root>
 </configuration>

--- a/backend/src/main/resources/logback/logback-local.xml
+++ b/backend/src/main/resources/logback/logback-local.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <property name="CONSOLE_LOG_PATTERN"
+    value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] %magenta([local]) %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/backend/src/main/resources/logback/logback-prod.xml
+++ b/backend/src/main/resources/logback/logback-prod.xml
@@ -1,0 +1,68 @@
+<configuration>
+  <property name="FILE_LOG_PATTERN"
+    value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] [prod] [%thread] %-5level [%C.%M:%L] - %msg%n"/>
+  <property name="LOGS_ROOT_PATH" value="/var/log/spring"/>
+
+  <!-- INFO 로그 설정 -->
+  <appender name="INFO_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/info/info.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>INFO</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <!-- WARN 로그 설정 -->
+  <appender name="WARN_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/warn/warn.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>WARN</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <!-- ERROR 로그 설정 -->
+  <appender name="ERROR_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/error/error.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>90</maxHistory>
+      <totalSizeCap>2GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="INFO_LOG_FILE"/>
+    <appender-ref ref="WARN_LOG_FILE"/>
+    <appender-ref ref="ERROR_LOG_FILE"/>
+  </root>
+</configuration>

--- a/backend/src/main/resources/logback/logback-prod.xml
+++ b/backend/src/main/resources/logback/logback-prod.xml
@@ -28,7 +28,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
       <fileNamePattern>${LOGS_ROOT_PATH}/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>10MB</maxFileSize>
-      <maxHistory>30</maxHistory>
+      <maxHistory>45</maxHistory>
       <totalSizeCap>1GB</totalSizeCap>
     </rollingPolicy>
     <encoder>

--- a/backend/src/main/resources/logback/logback-prod.xml
+++ b/backend/src/main/resources/logback/logback-prod.xml
@@ -3,66 +3,19 @@
     value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] [prod] [%thread] %-5level [%C.%M:%L] - %msg%n"/>
   <property name="LOGS_ROOT_PATH" value="/var/log/spring"/>
 
-  <!-- INFO 로그 설정 -->
-  <appender name="INFO_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/info/info.log</file>
+  <appender name="APP_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/app.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>30</maxHistory>
-      <totalSizeCap>1GB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>INFO</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-  </appender>
-
-  <!-- WARN 로그 설정 -->
-  <appender name="WARN_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/warn/warn.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>45</maxHistory>
-      <totalSizeCap>1GB</totalSizeCap>
-    </rollingPolicy>
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>WARN</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-  </appender>
-
-  <!-- ERROR 로그 설정 -->
-  <appender name="ERROR_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOGS_ROOT_PATH}/error/error.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOGS_ROOT_PATH}/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <fileNamePattern>${LOGS_ROOT_PATH}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxFileSize>10MB</maxFileSize>
       <maxHistory>90</maxHistory>
-      <totalSizeCap>2GB</totalSizeCap>
     </rollingPolicy>
     <encoder>
       <pattern>${FILE_LOG_PATTERN}</pattern>
     </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>ERROR</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
   </appender>
 
   <root level="info">
-    <appender-ref ref="INFO_LOG_FILE"/>
-    <appender-ref ref="WARN_LOG_FILE"/>
-    <appender-ref ref="ERROR_LOG_FILE"/>
+    <appender-ref ref="APP_LOG_FILE"/>
   </root>
 </configuration>

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/FeedbackStatisticServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/FeedbackStatisticServiceTest.java
@@ -92,7 +92,7 @@ public class FeedbackStatisticServiceTest extends ServiceIntegrationHelper {
         @DisplayName("당일 조회 테스트 케이스")
         void one_day() {
             final Organization organization = OrganizationFixture.createAllBlackBox();
-            organizationRepository.save(organization);
+            Organization savedOrganization = organizationRepository.save(organization);
             // given
             final PostedAt postedAt1 = PostedAt.from(LocalDateTime.now().minusDays(2L));// 이틀 전
             final PostedAt postedAt2 = PostedAt.from(LocalDateTime.now().minusDays(1L)); // 하루 전
@@ -109,7 +109,8 @@ public class FeedbackStatisticServiceTest extends ServiceIntegrationHelper {
             feedBackRepository.save(feedback3);
 
             // when
-            final StatisticResponse response = feedbackStatisticService.calculateStatistic(1L, "TODAY");
+            final StatisticResponse response = feedbackStatisticService.calculateStatistic(
+                    savedOrganization.getId(), "TODAY");
 
             // then
             assertThat(response.totalCount()).isEqualTo(1);
@@ -120,7 +121,7 @@ public class FeedbackStatisticServiceTest extends ServiceIntegrationHelper {
         void one_day_boundary_value() {
             // given
             final Organization organization = OrganizationFixture.createAllBlackBox();
-            organizationRepository.save(organization);
+            Organization savedOrganization = organizationRepository.save(organization);
 
             // 당일 전날의 23:59시
             final LocalDateTime targetDate1 = LocalDate.now().atStartOfDay().minusMinutes(1);
@@ -144,7 +145,8 @@ public class FeedbackStatisticServiceTest extends ServiceIntegrationHelper {
             feedBackRepository.save(feedback3);
 
             // when
-            final StatisticResponse response = feedbackStatisticService.calculateStatistic(1L, "TODAY");
+            final StatisticResponse response = feedbackStatisticService.calculateStatistic(
+                    savedOrganization.getId(), "TODAY");
 
             // then
             assertThat(response.totalCount()).isEqualTo(2); //targetDate2, targetDate3
@@ -155,7 +157,7 @@ public class FeedbackStatisticServiceTest extends ServiceIntegrationHelper {
         void once_a_week() {
             // given
             final Organization organization = OrganizationFixture.createAllBlackBox();
-            organizationRepository.save(organization);
+            Organization savedOrganization = organizationRepository.save(organization);
             final PostedAt postedAt1 = PostedAt.from(LocalDateTime.now().minusDays(7L));
             final PostedAt postedAt2 = PostedAt.from(LocalDateTime.now().minusDays(6L));
             final Feedback feedback1 = FeedbackFixture.createFeedbackWithPostedAtAndStatus(
@@ -166,7 +168,8 @@ public class FeedbackStatisticServiceTest extends ServiceIntegrationHelper {
             feedBackRepository.save(feedback2);
 
             // when
-            final StatisticResponse response = feedbackStatisticService.calculateStatistic(1L, "WEEK");
+            final StatisticResponse response = feedbackStatisticService.calculateStatistic(
+                    savedOrganization.getId(), "WEEK");
 
             // then
             assertThat(response.totalCount()).isEqualTo(1);


### PR DESCRIPTION
## 😉 연관 이슈

#287 

## 🚀 작업 내용

spring profile (local, dev, prod) 별 logback 설정 파일을 추가합니다.

## 💬 리뷰 중점사항

주요 설정은 아래와 같습니다.

- 각 로그 레벨별 디렉토리로 분류해 저장
ex)
/trace/trace-%d{yyyy-MM-dd}.%i.log
/info/info-%d{yyyy-MM-dd}.%i.log

- 로그 파일 롤링 정책 (RollingFileAppender)
maxFileSize: 하나의 로그 파일 최대 용량
maxHistory: 몇 개의 로그 파일을 저장할건지
totalSizeCap: 해당 레벨의 로그 파일 총 용량

입니다.

현재 설정된 값에서 바꾸고 싶은 부분이 있다면 의견 남겨주세요 ~~~

