### PR TITLE
[BE] feat: 단체 조회API 응답값 수정

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/organization/application/UserOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/UserOrganizationService.java
@@ -31,6 +31,6 @@ public class UserOrganizationService {
 
         organization.cheer(request.toCheeringCount());
 
-        return CheeringResponse.from(organization.getCheeringCount());
+        return CheeringResponse.from(organization.getCheeringCountValue());
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
@@ -34,4 +34,8 @@ public class Organization extends BaseTimeEntity {
     public void cheer(final CheeringCount other) {
         this.cheeringCount.add(other);
     }
+
+    public int getCheeringCountValue() {
+        return cheeringCount.getValue();
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/response/CheeringResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/response/CheeringResponse.java
@@ -1,6 +1,5 @@
 package feedzupzup.backend.organization.dto.response;
 
-import feedzupzup.backend.organization.domain.CheeringCount;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "응원하기 응답")
@@ -9,7 +8,7 @@ public record CheeringResponse(
         int cheeringTotalCount
 ) {
 
-        public static CheeringResponse from(final CheeringCount cheeringCount) {
-                return new CheeringResponse(cheeringCount.getValue());
+        public static CheeringResponse from(final int cheeringTotalCount) {
+                return new CheeringResponse(cheeringTotalCount);
         }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/response/UserOrganizationResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/response/UserOrganizationResponse.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "단체 조회 응답")
 public record UserOrganizationResponse(
         @Schema(description = "단체 이름", example = "우아한테크코스")
-        String organizationName
+        String organizationName,
+        @Schema(description = "응원 총 횟수", example = "10")
+        int totalCheeringCount
 ) {
     public static UserOrganizationResponse from(final Organization organization) {
-        return new UserOrganizationResponse(organization.getName());
+        return new UserOrganizationResponse(organization.getName(), organization.getCheeringCountValue());
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/organization/application/UserOrganizationServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/application/UserOrganizationServiceTest.java
@@ -42,6 +42,7 @@ class UserOrganizationServiceTest extends ServiceIntegrationHelper {
 
             // then
             assertThat(response.organizationName()).isEqualTo(organization.getName());
+            assertThat(response.totalCheeringCount()).isEqualTo(organization.getCheeringCountValue());
         }
 
         @Test

--- a/backend/src/test/java/feedzupzup/backend/organization/controller/OrganizationControllerE2ETest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/controller/OrganizationControllerE2ETest.java
@@ -36,7 +36,8 @@ class OrganizationControllerE2ETest extends E2EHelper {
                 .contentType(ContentType.JSON)
                 .body("status", equalTo(200))
                 .body("message", equalTo("OK"))
-                .body("data.organizationName", equalTo(organization.getName()));
+                .body("data.organizationName", equalTo(organization.getName()))
+                .body("data.totalCheeringCount", equalTo(organization.getCheeringCountValue()));
     }
 
     @Test

--- a/backend/src/test/java/feedzupzup/backend/organization/domain/OrganizationTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/domain/OrganizationTest.java
@@ -3,7 +3,6 @@ package feedzupzup.backend.organization.domain;
 import static org.assertj.core.api.Assertions.*;
 
 import feedzupzup.backend.organization.fixture.OrganizationFixture;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +22,6 @@ class OrganizationTest {
         organization.cheer(updateCheeringCount);
 
         // then
-        assertThat(organization.getCheeringCount()).isEqualTo(new CheeringCount(originCount + updateCount));
+        assertThat(organization.getCheeringCountValue()).isEqualTo(originCount + updateCount);
     }
 }


### PR DESCRIPTION
## 😉 연관 이슈
#292 

## 🚀 작업 내용
- 단체 조회 API 응답값에 해당 단체 응원횟수 추가

## 💬 리뷰 중점사항
