### PR TITLE
feat: IntersectionObserver의 rootMargin 값을 0px에서 140px으로 변경

### DIFF
--- a/frontend/src/hooks/useIntersectionObserve.ts
+++ b/frontend/src/hooks/useIntersectionObserve.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 const basicOptions: IntersectionObserverInit = {
   root: null,
-  rootMargin: '0px',
+  rootMargin: '140px',
   threshold: 0.5,
 };
 


### PR DESCRIPTION
## 😉 연관 이슈
#355 

## 🚀 작업 내용
- 무한 스크롤 `rootMargin` 기준을 140px로 조정
  - 140px 기준은 한줄 컴포넌트 높이입니당
<img width="702" height="399" alt="image" src="https://github.com/user-attachments/assets/74db5786-d64c-46f8-90c4-2143ef9f7b0e" />

## 💬 리뷰 중점사항
