### PR TITLE
[FE] fix: 게시물 컨텐츠 길이 길 때 넘치는 문제 해결 

### DIFF
--- a/frontend/src/domains/components/FeedbackText/FeedbackText.styles.ts
+++ b/frontend/src/domains/components/FeedbackText/FeedbackText.styles.ts
@@ -7,6 +7,7 @@ export const feedbackText = (
 ) => css`
   ${theme.typography.pretendard.caption}
 
+  line-height: 24px;
   white-space: pre-wrap;
   word-break: break-all;
   overflow-wrap: break-word;

--- a/frontend/src/domains/components/FeedbackText/FeedbackText.styles.ts
+++ b/frontend/src/domains/components/FeedbackText/FeedbackText.styles.ts
@@ -7,8 +7,10 @@ export const feedbackText = (
 ) => css`
   ${theme.typography.pretendard.caption}
 
-  line-height: 20px;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-wrap: break-word;
+  overflow: hidden;
 
   ${type === 'WAITING'
     ? `color : ${theme.colors.darkGray[100]}`

--- a/frontend/src/domains/components/FeedbackText/FeedbackText.styles.ts
+++ b/frontend/src/domains/components/FeedbackText/FeedbackText.styles.ts
@@ -10,7 +10,6 @@ export const feedbackText = (
   white-space: pre-wrap;
   word-break: break-all;
   overflow-wrap: break-word;
-  overflow: hidden;
 
   ${type === 'WAITING'
     ? `color : ${theme.colors.darkGray[100]}`


### PR DESCRIPTION
## 😉 연관 이슈
#345

## 🚀 작업 내용
- pre 속성 때문에 발생한 문제네요~ pre-wrap 속성으로 변경 + 추가 속성들 추가해둿슴다

## 💬 리뷰 중점사항

**이전**
<img width="1326" height="768" alt="image" src="https://github.com/user-attachments/assets/d17472b0-17ae-4727-8ca5-bfb3b4f8bc35" />

**변경 후**
<img width="568" height="423" alt="image" src="https://github.com/user-attachments/assets/69ec0b49-70a2-4e2a-a504-d2fdbf433cf3" />
