### PR TITLE
chore: 로컬 docker compose에서 스프링 부트 삭제

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,19 +1,4 @@
 services:
-  feed-zupzup-server:
-    container_name: feed-zupzup-server
-    build:
-      context: .
-      platforms:
-        - linux/arm64
-        - linux/amd64
-      args:
-        - SPRING_ACTIVE_PROFILE=local
-    ports:
-      - "8080:8080"
-    depends_on:
-      feed-zupzup-db:
-        condition: service_healthy
-
   feed-zupzup-db:
     image: mysql:8.4
     container_name: feed-zupzup-db
@@ -23,8 +8,4 @@ services:
     volumes:
       - ./mysql/data:/var/lib/mysql
     ports:
-      - "3306:3306"
-    healthcheck:
-      test: [ "CMD", "mysqladmin", "ping" ]
-      interval: 3s
-      retries: 10
+      - "33061:3306"


### PR DESCRIPTION
## 😉 연관 이슈

#456 

## 🚀 작업 내용

로컬 환경에서 실행하는 docker-compose.yml에서 spring boot를 삭제했습니다.

로컬에서 스프링 부트를 인텔리제이의 기능 (디버그, 브레이킹 포인트 등)을 활용하기 위함입니다~~

인텔리제이에서 아래 설정을 해주세요.
스프링 부트를 실행할 때 profile을 local로 설정하고 실행하기 위함입니다!

<img width="866" height="271" alt="스크린샷 2025-08-14 오후 7 54 22" src="https://github.com/user-attachments/assets/2af41164-036d-4938-ae38-ff025830ebbd" />

<br>
<br>
<br>

<img width="793" height="463" alt="스크린샷 2025-08-14 오후 7 54 38" src="https://github.com/user-attachments/assets/2d545f4a-a08e-4346-a442-7e87f7faa2e8" />



## 💬 리뷰 중점사항
