### PR TITLE
[BE] fix: 단체 저장 시 쿼리 실행 순서 변경

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -39,9 +39,11 @@ public class AdminOrganizationService {
             final Long adminId
     ) {
         final Organization organization = request.toOrganization();
+        final Organization savedOrganization = organizationRepository.save(organization);
+
         final Set<String> categories = request.categories();
 
-        saveOrganizationCategory(categories, organization);
+        saveOrganizationCategory(categories, savedOrganization);
 
         final Admin admin = findAdminBy(adminId);
         final Organizer organizer = new Organizer(
@@ -49,8 +51,6 @@ public class AdminOrganizationService {
                 admin,
                 OrganizerRole.OWNER
         );
-
-        final Organization savedOrganization = organizationRepository.save(organization);
         organizerRepository.save(organizer);
 
         eventPublisher.publishEvent(new OrganizationCreatedEvent(savedOrganization.getUuid()));


### PR DESCRIPTION
## 😉 연관 이슈

#497 

## 🚀 작업 내용

단체 저장 시 쿼리 실행 순서를 변경합니다.


## 💬 리뷰 중점사항
