### PR TITLE
[FE] fix: 관리자 헤더, 바텀네비게이션 안보이는 문제 해결 

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -10,24 +10,24 @@ import {
   moreMenu,
   moreMenuContainer,
 } from './Header.style';
-import { useLocation } from 'react-router-dom';
+
 import Button from '../@commons/Button/Button';
-import { LAYOUT_CONFIGS } from '@/constants/layoutConfig';
+
 import ArrowLeftIcon from '../icons/ArrowLeftIcon';
 import { useNavigate } from 'react-router-dom';
 import MoreMenu from '@/components/Header/MoreMenu/MoreMenu';
 import useMoreMenuManager from '@/components/Header/hooks/useMoreMenuManager';
+import { useLayoutConfig } from '@/hooks/useLayoutConfig';
 
 export default function Header() {
-  const location = useLocation();
   const theme = useAppTheme();
   const navigate = useNavigate();
+  const { layoutConfig } = useLayoutConfig();
 
   const { isOpenMoreMenu, toggleMoreMenu, moreButtonRef, closeMoreMenu } =
     useMoreMenuManager();
 
-  const { title, subtitle, hasMoreIcon, showBackButton } =
-    LAYOUT_CONFIGS[location.pathname].header;
+  const { title, subtitle, hasMoreIcon, showBackButton } = layoutConfig.header;
 
   const handleBackButtonClick = () => {
     navigate(-1);

--- a/frontend/src/constants/layoutConfig.ts
+++ b/frontend/src/constants/layoutConfig.ts
@@ -18,7 +18,7 @@ export interface LayoutConfig {
 }
 
 export const LAYOUT_CONFIGS: Record<string, LayoutConfig> = {
-  [ROUTES.ADMIN]: {
+  [`${ROUTES.ADMIN}/${ROUTES.DASHBOARD}`]: {
     header: {
       show: true,
       title: '피드백 관리',
@@ -30,7 +30,7 @@ export const LAYOUT_CONFIGS: Record<string, LayoutConfig> = {
       show: true,
     },
   },
-  [ROUTES.ADMIN_SETTINGS]: {
+  [`${ROUTES.ADMIN}/${ROUTES.ADMIN_SETTINGS}`]: {
     header: {
       show: true,
       title: '설정',
@@ -42,19 +42,7 @@ export const LAYOUT_CONFIGS: Record<string, LayoutConfig> = {
       show: true,
     },
   },
-  [ROUTES.NOTIFICATIONS]: {
-    header: {
-      show: true,
-      title: '알림 설정',
-      subtitle: '알림 확인 및 관리',
-      hasMoreIcon: false,
-      showBackButton: true,
-    },
-    bottomNav: {
-      show: false,
-    },
-  },
-  [ROUTES.ADMIN_HOME]: {
+  [`${ROUTES.ADMIN}/${ROUTES.ADMIN_HOME}`]: {
     header: {
       show: false,
     },

--- a/frontend/src/constants/navigationItems.ts
+++ b/frontend/src/constants/navigationItems.ts
@@ -14,13 +14,13 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   {
     id: 'home',
     label: '홈',
-    path: ROUTES.ADMIN_HOME,
+    path: `${ROUTES.ADMIN}/${ROUTES.ADMIN_HOME}`,
     Icon: HomeIcon,
   },
   {
     id: 'settings',
     label: '설정',
-    path: ROUTES.ADMIN_SETTINGS,
+    path: `${ROUTES.ADMIN}/${ROUTES.ADMIN_SETTINGS}`,
     Icon: SettingIcon,
   },
 ];

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -4,16 +4,12 @@ export type RouteValue = (typeof ROUTES)[RouteKey];
 export const ROUTES = {
   HOME: '/',
   SUBMIT: ':id/submit',
-  USER_DASHBOARD: ':id/dashboard',
+  DASHBOARD: ':id/dashboard',
   FEEDBACK_PAGE: 'feedback',
 
   ADMIN: '/admin',
   ADMIN_HOME: 'home',
   ADMIN_SETTINGS: 'settings',
-  ADMIN_DASHBOARD: ':id/dashboard',
-
-  NOTIFICATIONS: 'notifications',
-  SETTINGS: 'settings',
 
   LOGIN: 'login',
   SIGN_UP: 'signup',

--- a/frontend/src/hooks/useLayoutConfig.ts
+++ b/frontend/src/hooks/useLayoutConfig.ts
@@ -3,8 +3,36 @@ import { LAYOUT_CONFIGS } from '@/constants/layoutConfig';
 
 export const useLayoutConfig = () => {
   const location = useLocation();
+  const pathname = location.pathname;
 
-  const layoutConfig = LAYOUT_CONFIGS[location.pathname];
+  const getLayoutConfig = (pathname: string) => {
+    const exactMatch = LAYOUT_CONFIGS[pathname];
+
+    if (exactMatch) return exactMatch;
+
+    for (const [pattern, config] of Object.entries(LAYOUT_CONFIGS)) {
+      if (matchPattern(pathname, pattern)) {
+        return config;
+      }
+    }
+
+    return {
+      header: {
+        show: false,
+      },
+      bottomNav: {
+        show: false,
+      },
+    };
+  };
+
+  const matchPattern = (pathname: string, pattern: string): boolean => {
+    const regex = pattern.replace(/:[\w]+/g, '[^/]+');
+    const regexPattern = new RegExp(`^${regex}`);
+    return regexPattern.test(pathname);
+  };
+
+  const layoutConfig = getLayoutConfig(pathname);
 
   return {
     isShowHeader: layoutConfig?.header?.show ?? false,

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -18,15 +18,15 @@ export const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        index: true, // "/"에 접근 시
-        element: <Navigate to='/1/submit' replace />, // "/1/submit"로 리다이렉트 (임시 -> 나중에 삭제)
+        index: true,
+        element: <Navigate to='/1/submit' replace />,
       },
       {
         path: ROUTES.SUBMIT,
         element: <Home />,
       },
       {
-        path: ROUTES.USER_DASHBOARD,
+        path: ROUTES.DASHBOARD,
         element: <UserDashboard />,
       },
       {
@@ -37,25 +37,29 @@ export const router = createBrowserRouter([
         path: ROUTES.SIGN_UP,
         element: <SignUp />,
       },
-    ],
-  },
-  {
-    path: ROUTES.ADMIN,
-    element: (
-      <ProtectedRoute isAuthenticated={isAuthenticated} redirectPath='/login' />
-    ),
-    children: [
+
       {
-        path: ROUTES.ADMIN_HOME,
-        element: <AdminHome />,
-      },
-      {
-        path: ROUTES.ADMIN_DASHBOARD,
-        element: <AdminDashboard />,
-      },
-      {
-        path: ROUTES.ADMIN_SETTINGS,
-        element: <Settings />,
+        path: ROUTES.ADMIN,
+        element: (
+          <ProtectedRoute
+            isAuthenticated={isAuthenticated}
+            redirectPath='/login'
+          />
+        ),
+        children: [
+          {
+            path: ROUTES.ADMIN_HOME,
+            element: <AdminHome />,
+          },
+          {
+            path: ROUTES.DASHBOARD,
+            element: <AdminDashboard />,
+          },
+          {
+            path: ROUTES.ADMIN_SETTINGS,
+            element: <Settings />,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION


## 😉 연관 이슈
#487 

## 🚀 작업 내용
- 라우터 경로 수정: USER_DASHBOARD를 DASHBOARD로 변경 -> 둘이 내부 값이 같아서 오류가 나길래 수정했습니다.
- router.tsx구조 수정 : <App />에서 바텀네비, 헤더를 설정하는 로직이 있어서 admin과 user모두 App의 children이 되도록 수정했습니당.
- useLayoutConfig 훅에서 경로 패턴 매칭 로직 추가

## 💬 리뷰 중점사항
