### PR TITLE
[BE] feat: 단체 수정 API 구현

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/category/domain/Category.java
+++ b/backend/src/main/java/feedzupzup/backend/category/domain/Category.java
@@ -20,14 +20,19 @@ public enum Category {
 
     private final String koreanName;
 
-    public boolean isSameCategory(String value) {
+    public boolean isSameCategory(final String value) {
         return this.koreanName.equals(value);
     }
 
-    public static Category findCategoryBy(String value) {
+    public static Category findCategoryBy(final String value) {
         return Arrays.stream(Category.values())
                 .filter(result -> result.isSameCategory(value))
                 .findFirst()
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 카테고리입니다."));
+    }
+
+    public static boolean hasCategory(final String value) {
+        return Arrays.stream(Category.values())
+                .anyMatch(category -> category.isSameCategory(value));
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/category/domain/OrganizationCategory.java
+++ b/backend/src/main/java/feedzupzup/backend/category/domain/OrganizationCategory.java
@@ -37,15 +37,20 @@ public class OrganizationCategory extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Category category;
 
+    @Column(nullable = false)
+    private boolean isActive;
+
     @Column(name = "deleted_at")
     protected LocalDateTime deletedAt;
 
     public OrganizationCategory(
             final @NonNull Organization organization,
-            final @NonNull Category category
+            final @NonNull Category category,
+            final boolean isActive
     ) {
         this.organization = organization;
         this.category = category;
+        this.isActive = isActive;
     }
 
     public boolean isSameCategory(final Category category) {

--- a/backend/src/main/java/feedzupzup/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/global/exception/GlobalExceptionHandler.java
@@ -47,4 +47,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(httpStatus)
                 .body(ErrorResponse.error(e.getErrorCode()));
     }
+
+    @ExceptionHandler(UnAuthorizeException.class)
+    public ResponseEntity<ErrorResponse> handleUnAuthorizeException(final UnAuthorizeException e) {
+        log.warn(e.getMessage(), e);
+        final HttpStatus httpStatus = e.getErrorCode().getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(ErrorResponse.error(e.getErrorCode()));
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/global/exception/UnAuthorizeException.java
+++ b/backend/src/main/java/feedzupzup/backend/global/exception/UnAuthorizeException.java
@@ -1,0 +1,24 @@
+package feedzupzup.backend.global.exception;
+
+import feedzupzup.backend.global.response.ErrorCode;
+
+public class UnAuthorizeException extends CustomGlobalException{
+
+    protected UnAuthorizeException(final ErrorCode errorCode, final String message) {
+        super(errorCode, message);
+    }
+
+    public static final class InvalidAuthorizeException extends UnAuthorizeException {
+
+        private static final ErrorCode errorCode = ErrorCode.INVALID_AUTHORIZE;
+
+        public InvalidAuthorizeException(final String message) {
+            super(errorCode, message);
+        }
+
+        public InvalidAuthorizeException() {
+            super(errorCode, errorCode.getMessage());
+        }
+    }
+
+}

--- a/backend/src/main/java/feedzupzup/backend/global/response/ErrorCode.java
+++ b/backend/src/main/java/feedzupzup/backend/global/response/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND(NOT_FOUND, "G01", "요청한 자원을 찾을 수 없습니다"),
     NOT_SUPPORTED(BAD_REQUEST, "G02", "지원하지 않는 요청입니다"),
     RESOURCE_EXISTS(BAD_REQUEST, "G03", "이미 존재하는 자원입니다."),
+    INVALID_AUTHORIZE(UNAUTHORIZED, "G04", "접근 권한이 존재하지 않습니다."),
 
     //Organization Error
     CHEERING_INVALID_NUMBER(BAD_REQUEST, "O01", "응원횟수에 유효하지 않은 숫자값입니다."),

--- a/backend/src/main/java/feedzupzup/backend/organization/api/AdminOrganizationApi.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/api/AdminOrganizationApi.java
@@ -4,16 +4,21 @@ import feedzupzup.backend.admin.dto.AdminSession;
 import feedzupzup.backend.auth.presentation.annotation.AdminAuthenticationPrincipal;
 import feedzupzup.backend.global.response.SuccessResponse;
 import feedzupzup.backend.organization.dto.request.CreateOrganizationRequest;
+import feedzupzup.backend.organization.dto.request.UpdateOrganizationRequest;
 import feedzupzup.backend.organization.dto.response.AdminCreateOrganizationResponse;
 import feedzupzup.backend.organization.dto.response.AdminInquireOrganizationResponse;
+import feedzupzup.backend.organization.dto.response.AdminUpdateOrganizationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -30,6 +35,22 @@ public interface AdminOrganizationApi {
     SuccessResponse<AdminCreateOrganizationResponse> createOrganization(
             @Parameter(hidden = true) @AdminAuthenticationPrincipal final AdminSession adminSession,
             @RequestBody final CreateOrganizationRequest createOrganizationRequest
+    );
+
+    @Operation(summary = "단체 수정", description = "단체을 수정할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "수정 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "401", ref = "#/components/responses/Unauthorized"),
+            @ApiResponse(responseCode = "403", ref = "#/components/responses/Forbidden")
+    })
+    @ResponseStatus(HttpStatus.CREATED)
+    @PutMapping("/admin/organizations/{organizationUuid}")
+    SuccessResponse<AdminUpdateOrganizationResponse> updateOrganization(
+            @Parameter(description = "단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable("organizationUuid") final UUID organizationUuid,
+
+            @Parameter(hidden = true) @AdminAuthenticationPrincipal final AdminSession adminSession,
+            @RequestBody final UpdateOrganizationRequest updateOrganizationRequest
     );
 
     @Operation(summary = "단체 조회", description = "본인이 속한 단체을 모두 조회할 수 있습니다.")

--- a/backend/src/main/java/feedzupzup/backend/organization/api/AdminOrganizationApi.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/api/AdminOrganizationApi.java
@@ -43,7 +43,7 @@ public interface AdminOrganizationApi {
             @ApiResponse(responseCode = "401", ref = "#/components/responses/Unauthorized"),
             @ApiResponse(responseCode = "403", ref = "#/components/responses/Forbidden")
     })
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.OK)
     @PutMapping("/admin/organizations/{organizationUuid}")
     SuccessResponse<AdminUpdateOrganizationResponse> updateOrganization(
             @Parameter(description = "단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000")

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -77,7 +77,7 @@ public class AdminOrganizationService {
             final Set<String> categories,
             final Organization organization
     ) {
-        final OrganizationCategories organizationCategories = OrganizationCategories.createAndConvert(
+        final OrganizationCategories organizationCategories = OrganizationCategories.createOf(
                 categories, organization);
         organization.addOrganizationCategories(organizationCategories.getOrganizationCategories());
         organizationCategoryRepository.saveAll(organizationCategories.getOrganizationCategories());

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -97,7 +97,8 @@ public class AdminOrganizationService {
                 .orElseThrow(() -> new ResourceNotFoundException("해당 UUID를 가진 단체는 존재하지 않습니다."));
 
         // TODO : Exception 변경하기
-        if (organizerRepository.existsOrganizerByAdminIdAndOrganizationId(organization.getId(), adminId)) {
+        if (!organizerRepository.existsOrganizerByAdmin_IdAndOrganization_Id(adminId,
+                organization.getId())) {
             throw new ResourceNotFoundException("해당 단체에 대한 접근 권한이 없습니다.");
         }
 
@@ -110,5 +111,7 @@ public class AdminOrganizationService {
                 request.organizationName()
         );
         return AdminUpdateOrganizationResponse.from(organization);
+
+        // TODO: 연관관계 전이 때문에 반영이 안 될 것이다. 이를 수정해라.
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -4,6 +4,8 @@ import feedzupzup.backend.admin.domain.Admin;
 import feedzupzup.backend.admin.domain.AdminRepository;
 import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
+import feedzupzup.backend.global.exception.UnAuthorizeException;
+import feedzupzup.backend.global.exception.UnAuthorizeException.InvalidAuthorizeException;
 import feedzupzup.backend.organization.domain.AdminOrganizationInfo;
 import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationCategories;
@@ -96,10 +98,9 @@ public class AdminOrganizationService {
         final Organization organization = organizationRepository.findByUuid(organizationUuid)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 UUID를 가진 단체는 존재하지 않습니다."));
 
-        // TODO : Exception 변경하기
         if (!organizerRepository.existsOrganizerByAdmin_IdAndOrganization_Id(adminId,
                 organization.getId())) {
-            throw new ResourceNotFoundException("해당 단체에 대한 접근 권한이 없습니다.");
+            throw new InvalidAuthorizeException("해당 단체 "+ "id = " + organization.getId() + "에 대한 접근 권한이 없습니다.");
         }
 
         final Set<String> categories = request.categories();

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -110,8 +110,6 @@ public class AdminOrganizationService {
                 organizationCategories.getOrganizationCategories(),
                 request.organizationName()
         );
-        return AdminUpdateOrganizationResponse.from(organization);
-
-        // TODO: 연관관계 전이 때문에 반영이 안 될 것이다. 이를 수정해라.
+        return AdminUpdateOrganizationResponse.from(organization, organizationCategories);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/application/UserOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/UserOrganizationService.java
@@ -2,6 +2,7 @@ package feedzupzup.backend.organization.application;
 
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationCategories;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.organization.dto.request.CheeringRequest;
 import feedzupzup.backend.organization.dto.response.CheeringResponse;
@@ -23,7 +24,10 @@ public class UserOrganizationService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "해당 ID(id = " + organizationUuid + ")인 단체를 찾을 수 없습니다."));
 
-        return UserOrganizationResponse.from(organization);
+        final OrganizationCategories organizationCategories = OrganizationCategories.createFromOrganization(
+                organization);
+
+        return UserOrganizationResponse.from(organization, organizationCategories);
     }
 
     @Transactional

--- a/backend/src/main/java/feedzupzup/backend/organization/controller/AdminOrganizationController.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/controller/AdminOrganizationController.java
@@ -6,9 +6,12 @@ import feedzupzup.backend.global.response.SuccessResponse;
 import feedzupzup.backend.organization.api.AdminOrganizationApi;
 import feedzupzup.backend.organization.application.AdminOrganizationService;
 import feedzupzup.backend.organization.dto.request.CreateOrganizationRequest;
+import feedzupzup.backend.organization.dto.request.UpdateOrganizationRequest;
 import feedzupzup.backend.organization.dto.response.AdminCreateOrganizationResponse;
 import feedzupzup.backend.organization.dto.response.AdminInquireOrganizationResponse;
+import feedzupzup.backend.organization.dto.response.AdminUpdateOrganizationResponse;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +30,18 @@ public class AdminOrganizationController implements AdminOrganizationApi {
         final AdminCreateOrganizationResponse response = adminOrganizationService.createOrganization(
                 request, adminSession.adminId());
         return SuccessResponse.success(HttpStatus.CREATED, response);
+    }
+
+    @Override
+    public SuccessResponse<AdminUpdateOrganizationResponse> updateOrganization(
+            final UUID organizationUuid,
+            @AdminAuthenticationPrincipal final AdminSession adminSession,
+            final UpdateOrganizationRequest request
+    ) {
+        final AdminUpdateOrganizationResponse response = adminOrganizationService.updateOrganization(
+                organizationUuid, request, adminSession.adminId()
+        );
+        return SuccessResponse.success(HttpStatus.OK, response);
     }
 
     @Override

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
@@ -86,4 +86,13 @@ public class Organization extends BaseTimeEntity {
     public void addOrganizationCategories(final Set<OrganizationCategory> organizationCategories) {
         this.organizationCategories.addAll(organizationCategories);
     }
+
+    public void updateOrganizationCategoriesAndName(
+            final Set<OrganizationCategory> organizationCategories,
+            final String name
+    ) {
+        this.organizationCategories.clear();
+        this.organizationCategories.addAll(organizationCategories);
+        this.name = new Name(name);
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
@@ -6,6 +6,7 @@ import feedzupzup.backend.global.BaseTimeEntity;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.vo.CheeringCount;
 import feedzupzup.backend.organization.domain.vo.Name;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -49,7 +50,7 @@ public class Organization extends BaseTimeEntity {
     @Column(name = "deleted_at")
     protected LocalDateTime deletedAt;
 
-    @OneToMany(mappedBy = "organization")
+    @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL, orphanRemoval = true)
     private final Set<OrganizationCategory> organizationCategories = new HashSet<>();
 
     @Builder

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/Organization.java
@@ -72,10 +72,15 @@ public class Organization extends BaseTimeEntity {
     }
 
     public OrganizationCategory findOrganizationCategoryBy(final Category category) {
-        return organizationCategories.stream()
+        final OrganizationCategory resultCategory = organizationCategories.stream()
                 .filter(organizationCategory -> organizationCategory.isSameCategory(category))
                 .findFirst()
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 카테고리입니다."));
+
+        if (!resultCategory.isActive()) {
+            throw new ResourceNotFoundException("해당 카테고리는 현재 비활성화 되어있습니다.");
+        }
+        return resultCategory;
     }
 
     public void addOrganizationCategories(final Set<OrganizationCategory> organizationCategories) {

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
@@ -18,15 +18,28 @@ public class OrganizationCategories {
                 mapToOrganizationCategories(categories, organization));
     }
 
-    public static OrganizationCategories createOf(final Set<String> categories, final Organization organization) {
+    private OrganizationCategories(final Set<OrganizationCategory> organizationCategories) {
+        this.organizationCategories = new HashSet<>(organizationCategories);
+    }
+
+    public static OrganizationCategories createOf(
+            final Set<String> categories,
+            final Organization organization
+    ) {
         return new OrganizationCategories(categories, organization);
     }
 
-    private Set<OrganizationCategory> mapToOrganizationCategories(final Set<String> categories, final Organization organization) {
+    public static OrganizationCategories createFromOrganization(final Organization organization) {
+        return new OrganizationCategories(organization.getOrganizationCategories());
+    }
+
+    private Set<OrganizationCategory> mapToOrganizationCategories(final Set<String> categories,
+            final Organization organization) {
         validateCategories(categories);
         return Arrays.stream(Category.values())
                 .map(category ->
-                        new OrganizationCategory(organization, category, categories.contains(category.getKoreanName())))
+                        new OrganizationCategory(organization, category,
+                                categories.contains(category.getKoreanName())))
                 .collect(Collectors.toSet());
     }
 
@@ -41,5 +54,11 @@ public class OrganizationCategories {
 
     public Set<OrganizationCategory> getOrganizationCategories() {
         return Collections.unmodifiableSet(organizationCategories);
+    }
+
+    public Set<OrganizationCategory> getActiveCategories() {
+        return organizationCategories.stream()
+                .filter(OrganizationCategory::isActive)
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
@@ -2,6 +2,8 @@ package feedzupzup.backend.organization.domain;
 
 import feedzupzup.backend.category.domain.Category;
 import feedzupzup.backend.category.domain.OrganizationCategory;
+import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -12,18 +14,29 @@ public class OrganizationCategories {
     private final Set<OrganizationCategory> organizationCategories;
 
     private OrganizationCategories(final Set<String> categories, final Organization organization) {
-        this.organizationCategories = new HashSet<>(convertOf(categories, organization));
+        this.organizationCategories = new HashSet<>(
+                mapToOrganizationCategories(categories, organization));
     }
 
-    public static OrganizationCategories createAndConvert(final Set<String> categories, final Organization organization) {
+    public static OrganizationCategories createOf(final Set<String> categories, final Organization organization) {
         return new OrganizationCategories(categories, organization);
     }
 
-    private Set<OrganizationCategory> convertOf(final Set<String> categories, final Organization organization) {
-        return categories.stream()
-                .map(categoryName ->
-                        new OrganizationCategory(organization, Category.findCategoryBy(categoryName)))
+    private Set<OrganizationCategory> mapToOrganizationCategories(final Set<String> categories, final Organization organization) {
+        validateCategories(categories);
+        return Arrays.stream(Category.values())
+                .map(category ->
+                        new OrganizationCategory(organization, category, categories.contains(category.getKoreanName())))
                 .collect(Collectors.toSet());
+    }
+
+    private void validateCategories(final Set<String> categories) {
+        for (String category : categories) {
+            if (Category.hasCategory(category)) {
+                return;
+            }
+            throw new ResourceNotFoundException("category " + category + " 는 존재하지 않는 카테고리입니다.");
+        }
     }
 
     public Set<OrganizationCategory> getOrganizationCategories() {

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/request/UpdateOrganizationRequest.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/request/UpdateOrganizationRequest.java
@@ -1,11 +1,7 @@
 package feedzupzup.backend.organization.dto.request;
 
-import feedzupzup.backend.organization.domain.Organization;
-import feedzupzup.backend.organization.domain.vo.CheeringCount;
-import feedzupzup.backend.organization.domain.vo.Name;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Set;
-import java.util.UUID;
 
 @Schema(description = "단체 수정 요청")
 public record UpdateOrganizationRequest(
@@ -15,10 +11,5 @@ public record UpdateOrganizationRequest(
         @Schema(description = "카테고리 리스트", example = "[\"건의\", \"신고\"]")
         Set<String> categories
 ) {
-
-    public Organization toOrganization() {
-        return new Organization(UUID.randomUUID(), new Name(organizationName),
-                new CheeringCount(0));
-    }
 
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/request/UpdateOrganizationRequest.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/request/UpdateOrganizationRequest.java
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Set;
 import java.util.UUID;
 
-@Schema(description = "단체 저장 요청")
-public record CreateOrganizationRequest(
+@Schema(description = "단체 수정 요청")
+public record UpdateOrganizationRequest(
         @Schema(description = "단체 이름", example = "우아한테크코스")
         String organizationName,
 
@@ -17,7 +17,8 @@ public record CreateOrganizationRequest(
 ) {
 
     public Organization toOrganization() {
-        return new Organization(UUID.randomUUID(), new Name(organizationName), new CheeringCount(0));
+        return new Organization(UUID.randomUUID(), new Name(organizationName),
+                new CheeringCount(0));
     }
 
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/response/AdminCreateOrganizationResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/response/AdminCreateOrganizationResponse.java
@@ -3,9 +3,9 @@ package feedzupzup.backend.organization.dto.response;
 import feedzupzup.backend.organization.domain.Organization;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "조직 생성 응답")
+@Schema(description = "단체 생성 응답")
 public record AdminCreateOrganizationResponse(
-        @Schema(description = "생성된 조직 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
+        @Schema(description = "생성된 단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
         String organizationUuid
 ) {
 

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/response/AdminUpdateOrganizationResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/response/AdminUpdateOrganizationResponse.java
@@ -1,0 +1,15 @@
+package feedzupzup.backend.organization.dto.response;
+
+import feedzupzup.backend.organization.domain.Organization;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "단체 수정 응답")
+public record AdminUpdateOrganizationResponse(
+        @Schema(description = "수정된 단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
+        String organizationUuid
+) {
+
+    public static AdminUpdateOrganizationResponse from(final Organization organization) {
+        return new AdminUpdateOrganizationResponse(organization.getUuid().toString());
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/response/AdminUpdateOrganizationResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/response/AdminUpdateOrganizationResponse.java
@@ -1,15 +1,41 @@
 package feedzupzup.backend.organization.dto.response;
 
+import feedzupzup.backend.category.domain.OrganizationCategory;
 import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationCategories;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Schema(description = "단체 수정 응답")
 public record AdminUpdateOrganizationResponse(
         @Schema(description = "수정된 단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
-        String organizationUuid
+        String organizationUuid,
+
+        @Schema(description = "수정된 단체 이름", example = "우아한테크코스")
+        String updateName,
+
+        @Schema(description = "수정된 카테고리", example = "[\"건의\", \"신고\"]")
+        Set<String> updateCategories
 ) {
 
-    public static AdminUpdateOrganizationResponse from(final Organization organization) {
-        return new AdminUpdateOrganizationResponse(organization.getUuid().toString());
+    public static AdminUpdateOrganizationResponse from(
+            final Organization organization,
+            final OrganizationCategories organizationCategories
+    ) {
+
+        return new AdminUpdateOrganizationResponse(
+                organization.getUuid().toString(),
+                organization.getName().getValue(),
+                convertCategories(organizationCategories.getActiveCategories())
+        );
+    }
+
+    private static Set<String> convertCategories(
+            final Set<OrganizationCategory> organizationCategories
+    ) {
+        return organizationCategories.stream()
+                .map(result -> result.getCategory().getKoreanName())
+                .collect(Collectors.toSet());
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/dto/response/UserOrganizationResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/dto/response/UserOrganizationResponse.java
@@ -2,6 +2,7 @@ package feedzupzup.backend.organization.dto.response;
 
 import feedzupzup.backend.category.domain.OrganizationCategory;
 import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationCategories;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,18 +13,24 @@ public record UserOrganizationResponse(
         String organizationName,
         @Schema(description = "응원 총 횟수", example = "10")
         int totalCheeringCount,
-        @Schema(description = "카테고리 리스트", example = "[\"시설\", \"행정\", \"커리큘럼\"]")
+        @Schema(description = "카테고리 리스트", example = "[\"건의\", \"신고\", \"기타\"]")
         Set<String> categories
-        ) {
-    public static UserOrganizationResponse from(final Organization organization) {
+) {
+
+    public static UserOrganizationResponse from(
+            final Organization organization,
+            final OrganizationCategories organizationCategories
+    ) {
         return new UserOrganizationResponse(
                 organization.getName().getValue(),
                 organization.getCheeringCountValue(),
-                convertCategories(organization.getOrganizationCategories())
+                convertCategories(organizationCategories.getActiveCategories())
         );
     }
 
-    private static Set<String> convertCategories(final Set<OrganizationCategory> organizationCategories) {
+    private static Set<String> convertCategories(
+            final Set<OrganizationCategory> organizationCategories
+    ) {
         return organizationCategories.stream()
                 .map(result -> result.getCategory().getKoreanName())
                 .collect(Collectors.toSet());

--- a/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
@@ -1,5 +1,6 @@
 package feedzupzup.backend.organizer.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface OrganizerRepository extends JpaRepository<Organizer, Long> {
 
     List<Organizer> findByOrganizationId(Long organizationId);
+
+    boolean existsOrganizerByAdminIdAndOrganizationId(Long adminId, Long organizationId);
 }

--- a/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
@@ -1,6 +1,5 @@
 package feedzupzup.backend.organizer.domain;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +8,5 @@ public interface OrganizerRepository extends JpaRepository<Organizer, Long> {
 
     List<Organizer> findByOrganizationId(Long organizationId);
 
-    boolean existsOrganizerByAdminIdAndOrganizationId(Long adminId, Long organizationId);
+    boolean existsOrganizerByAdmin_IdAndOrganization_Id(Long adminId, Long organizationId);
 }

--- a/backend/src/main/resources/db/migration/V21_add_column_is_active_to_organization_category.sql
+++ b/backend/src/main/resources/db/migration/V21_add_column_is_active_to_organization_category.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organization_category ADD COLUMN is_active BIT(1) NOT NULL DEFAULT 0;

--- a/backend/src/test/java/feedzupzup/backend/admin/domain/fixture/AdminFixture.java
+++ b/backend/src/test/java/feedzupzup/backend/admin/domain/fixture/AdminFixture.java
@@ -14,4 +14,11 @@ public class AdminFixture {
                 new AdminName("lisa"));
     }
 
+    public static Admin createFromLoginId(final String loginId) {
+        return new Admin(
+                new LoginId(loginId),
+                new EncodedPassword("password123"),
+                new AdminName("lisa"));
+    }
+
 }

--- a/backend/src/test/java/feedzupzup/backend/category/fixture/OrganizationCategoryFixture.java
+++ b/backend/src/test/java/feedzupzup/backend/category/fixture/OrganizationCategoryFixture.java
@@ -9,11 +9,11 @@ public class OrganizationCategoryFixture {
     public static OrganizationCategory createOrganizationCategory(
             final Organization organization,
             final Category category) {
-        return new OrganizationCategory(organization, category);
+        return new OrganizationCategory(organization, category, true);
     }
 
     public static OrganizationCategory createOrganizationCategory(Organization organization) {
-        return new OrganizationCategory(organization, Category.ETC);
+        return new OrganizationCategory(organization, Category.ETC, true);
     }
 
 }

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/UserFeedbackServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/UserFeedbackServiceTest.java
@@ -62,7 +62,7 @@ class UserFeedbackServiceTest extends ServiceIntegrationHelper {
         //given
         final Organization organization = OrganizationFixture.createAllBlackBox();
         organizationRepository.save(organization);
-        final OrganizationCategory organizationCategory = new OrganizationCategory(organization, SUGGESTION);
+        final OrganizationCategory organizationCategory = new OrganizationCategory(organization, SUGGESTION, true);
         organizationCategoryRepository.save(organizationCategory);
 
         final CreateFeedbackRequest request = new CreateFeedbackRequest("맛있어요", false, "윌슨", "건의");

--- a/backend/src/test/java/feedzupzup/backend/organization/application/AdminOrganizationServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/application/AdminOrganizationServiceTest.java
@@ -8,9 +8,13 @@ import feedzupzup.backend.admin.domain.AdminRepository;
 import feedzupzup.backend.admin.domain.fixture.AdminFixture;
 import feedzupzup.backend.config.ServiceIntegrationHelper;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
+import feedzupzup.backend.global.exception.UnAuthorizeException.InvalidAuthorizeException;
 import feedzupzup.backend.organization.dto.request.CreateOrganizationRequest;
+import feedzupzup.backend.organization.dto.request.UpdateOrganizationRequest;
 import feedzupzup.backend.organization.dto.response.AdminCreateOrganizationResponse;
+import feedzupzup.backend.organization.dto.response.AdminUpdateOrganizationResponse;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +68,66 @@ class AdminOrganizationServiceTest extends ServiceIntegrationHelper {
         final Admin admin = createAndSaveAdmin();
         assertThatThrownBy(() -> adminOrganizationService.createOrganization(createOrganizationRequest, admin.getId()))
                 .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("권한이 있는 admin이 본인의 단체를 수정할 수 있어야 한다")
+    void update_organization_success() {
+        // given
+        CreateOrganizationRequest request =
+                new CreateOrganizationRequest(
+                        "우테코",
+                        Set.of("건의", "신고")
+                );
+
+        final Admin savedAdmin = createAndSaveAdmin();
+
+        final AdminCreateOrganizationResponse createResponse = adminOrganizationService.createOrganization(
+                request, savedAdmin.getId());
+
+        UpdateOrganizationRequest updateOrganizationRequest = new UpdateOrganizationRequest(
+                "우테코코코", Set.of("기타", "칭찬", "정보공유")
+        );
+        final UUID organizationUuid = UUID.fromString(createResponse.organizationUuid());
+
+        // when
+        final AdminUpdateOrganizationResponse updateResponse = adminOrganizationService.updateOrganization(
+                organizationUuid,
+                updateOrganizationRequest,
+                savedAdmin.getId()
+        );
+
+        // then
+        assertThat(updateResponse.updateName()).isEqualTo("우테코코코");
+        assertThat(updateResponse.updateCategories()).containsExactlyInAnyOrder("기타", "칭찬", "정보공유");
+    }
+
+    @Test
+    @DisplayName("단체 수정 권한이 없는 admin이 수정 요청을 보낼경우, 예외가 발생해야 한다")
+    void update_organization_not_authorize_case() {
+        // given
+        final Admin savedAdmin = createAndSaveAdmin();
+        final Admin otherAdmin = AdminFixture.createFromLoginId("otherAdmin");
+        adminRepository.save(otherAdmin);
+
+        CreateOrganizationRequest request =
+                new CreateOrganizationRequest(
+                        "우테코",
+                        Set.of("건의", "신고")
+                );
+
+        final AdminCreateOrganizationResponse createResponse = adminOrganizationService.createOrganization(
+                request, savedAdmin.getId());
+
+        UpdateOrganizationRequest updateOrganizationRequest = new UpdateOrganizationRequest(
+                "우테코코코", Set.of("기타", "칭찬", "정보공유")
+        );
+        final UUID organizationUuid = UUID.fromString(createResponse.organizationUuid());
+
+        // when, then
+        assertThatThrownBy(() -> adminOrganizationService.updateOrganization(
+                organizationUuid, updateOrganizationRequest, otherAdmin.getId()))
+                .isInstanceOf(InvalidAuthorizeException.class);
     }
 
     private Admin createAndSaveAdmin() {

--- a/backend/src/test/java/feedzupzup/backend/organization/domain/OrganizationRepositoryTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/domain/OrganizationRepositoryTest.java
@@ -63,9 +63,9 @@ class OrganizationRepositoryTest extends RepositoryHelper {
             organizerRepository.save(new Organizer(organization2, admin, OrganizerRole.OWNER));
 
             organizationCategory1 = organizationCategoryRepository.save(
-                    new OrganizationCategory(organization1, Category.ETC));
+                    new OrganizationCategory(organization1, Category.ETC, true));
             organizationCategory2 = organizationCategoryRepository.save(
-                    new OrganizationCategory(organization2, Category.ETC));
+                    new OrganizationCategory(organization2, Category.ETC, true));
         }
 
         @Test


### PR DESCRIPTION
## 😉 연관 이슈
#508 

## 🚀 작업 내용
- 단체 수정 API 구현

### 단체 수정 API 구현으로 인한 변경 사항
코드 리뷰 전 flow 이해하고 가는게 편할 것 같아 적어둡니다.
1. 모든 Category를 organization_category에 저장합니다.
2. 필드 is_active = true이면, 해당 organization에서 현재 사용하고 있는 카테고리가 됩니다.
3. 추후에 category를 변경하고, 변경 카테고리에 속하지 않는다면 is_active = false로 변경합니다.

### 위와 같이 구현한 이유
카테고리가 변경되어도, 기존의 카테고리 데이터를 유지하기 위해서

## 💬 리뷰 중점사항


