### PR TITLE
[FE] chore: PWA로 접속시 관리자 페이지로 바로 이동하도록 수정

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,4 +1,4 @@
-import { ROUTES } from '@/constants/routes';
+import { ADMIN_BASE, ROUTES } from '@/constants/routes';
 import AdminDashboard from '@/domains/admin/adminDashboard/AdminDashboard';
 import Login from '@/domains/admin/Login/Login';
 import SignUp from '@/domains/admin/SignUp/SignUp';
@@ -11,6 +11,7 @@ import App from './App';
 import AdminHome from './domains/admin/AdminHome/AdminHome';
 import Settings from './domains/admin/Settings/Settings';
 import NotFoundPage from './components/NotFoundPage/NotFoundPage';
+import { isAuthenticated } from './utils/isAuthenticated';
 
 export const router = createBrowserRouter([
   {
@@ -19,8 +20,10 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: (
-          <Navigate to='/d0b1b979-7ae8-11f0-8408-0242ac120002/submit' replace />
+        element: isAuthenticated() ? (
+          <Navigate to={ADMIN_BASE + ROUTES.ADMIN_HOME} replace />
+        ) : (
+          <Navigate to='/login' replace />
         ),
       },
       {


### PR DESCRIPTION
## 😉 연관 이슈
#525 

## 🚀 작업 내용
- 이전에 /에 들어가면 자동으로 대쉬보드로 이동하도록 세팅되어있었는데요.
- 사용자는 url,혹은 QR로 이동하기때문에 위의 로직을 수정했습니다. 앱에 들어가자마자 로그인 확인 로직을 돌려서 로그인 안되어있다면 login, 되어있다면 home으로 이동하게 수정했습니다. 
- manifest.json를 사용해서 login으로 바로 이동시키지 않은 이유는 화면이 깜빡거리는 UX문제가 있었기때문입니당.

## 💬 리뷰 중점사항
