### PR TITLE
[FE] refactor: useNavigate 커스텀 훅으로 분리하기

### DIFF
--- a/frontend/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/frontend/src/components/BottomNavigation/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { useKeyboardDetection } from '@/hooks/useKeyboardDetection';
 import {
@@ -10,6 +10,7 @@ import {
   NAVIGATION_ITEMS,
   NavigationItem,
 } from '../../constants/navigationItems';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 interface NavItemProps {
   item: NavigationItem;
@@ -34,14 +35,10 @@ function NavItem({ item, isActive, onNavigate }: NavItemProps) {
 }
 
 export default function BottomNavigation() {
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const location = useLocation();
   const theme = useAppTheme();
   const isKeyboardOpen = useKeyboardDetection();
-
-  const handleNavigate = (path: string) => {
-    navigate(path);
-  };
 
   return (
     <nav
@@ -53,7 +50,7 @@ export default function BottomNavigation() {
           key={item.id}
           item={item}
           isActive={location.pathname === item.path}
-          onNavigate={handleNavigate}
+          onNavigate={goPath}
         />
       ))}
     </nav>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -14,14 +14,14 @@ import {
 import Button from '../@commons/Button/Button';
 
 import ArrowLeftIcon from '../icons/ArrowLeftIcon';
-import { useNavigate } from 'react-router-dom';
 import MoreMenu from '@/components/Header/MoreMenu/MoreMenu';
 import useMoreMenuManager from '@/components/Header/hooks/useMoreMenuManager';
 import { useLayoutConfig } from '@/hooks/useLayoutConfig';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 export default function Header() {
   const theme = useAppTheme();
-  const navigate = useNavigate();
+  const { goBack } = useNavigation();
   const { layoutConfig } = useLayoutConfig();
 
   const { isOpenMoreMenu, toggleMoreMenu, moreButtonRef, closeMoreMenu } =
@@ -29,15 +29,11 @@ export default function Header() {
 
   const { title, subtitle, hasMoreIcon, showBackButton } = layoutConfig.header;
 
-  const handleBackButtonClick = () => {
-    navigate(-1);
-  };
-
   return (
     <header css={header(theme)}>
       <div css={arrowTitleContainer}>
         {showBackButton && (
-          <Button onClick={handleBackButtonClick}>
+          <Button onClick={goBack}>
             <ArrowLeftIcon color={theme.colors.white[100]} />
           </Button>
         )}

--- a/frontend/src/components/NotFoundPage/NotFoundPage.tsx
+++ b/frontend/src/components/NotFoundPage/NotFoundPage.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import BasicButton from '@/components/BasicButton/BasicButton';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import {
@@ -8,14 +7,11 @@ import {
   title,
   description,
 } from './NotFoundPage.styles';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 export default function NotFoundPage() {
   const theme = useAppTheme();
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate(-1);
-  };
+  const { goBack } = useNavigation();
 
   return (
     <div css={container}>
@@ -25,7 +21,7 @@ export default function NotFoundPage() {
         <p css={description(theme)}>
           요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
         </p>
-        <BasicButton onClick={handleGoBack} variant='primary' height={'30px'}>
+        <BasicButton onClick={goBack} variant='primary' height={'30px'}>
           돌아가기
         </BasicButton>
       </div>

--- a/frontend/src/domains/admin/AdminHome/components/AdminOrganizationList/AdminOrganizationList.tsx
+++ b/frontend/src/domains/admin/AdminHome/components/AdminOrganizationList/AdminOrganizationList.tsx
@@ -7,7 +7,7 @@ import {
   emptyAdminOrganization,
 } from '@/domains/admin/AdminHome/components/AdminOrganizationList/AdminOrganizationList.style';
 import StatusBox from '@/domains/components/StatusBox/StatusBox';
-import { useNavigate } from 'react-router-dom';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 interface AdminOrganizationListProps {
   adminOrganizations: AdminOrganizationType[];
@@ -18,7 +18,7 @@ export default function AdminOrganizationList({
   adminOrganizations,
   isLoading,
 }: AdminOrganizationListProps) {
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
 
   if (isLoading) {
     return (
@@ -48,7 +48,7 @@ export default function AdminOrganizationList({
             organizationName={organizations.name}
             waitingCount={organizations.waitingCount}
             postedAt={organizations.postedAt}
-            onClick={() => navigate(`/admin/${organizations.uuid}/dashboard`)}
+            onClick={() => goPath(`/admin/${organizations.uuid}/dashboard`)}
           />
         ))
       )}

--- a/frontend/src/domains/admin/Login/Login.tsx
+++ b/frontend/src/domains/admin/Login/Login.tsx
@@ -17,8 +17,8 @@ import {
   validateId,
   validatePassword,
 } from '@/domains/admin/utils/authValidations';
+import useNavigation from '@/domains/hooks/useNavigation';
 import { useAppTheme } from '@/hooks/useAppTheme';
-import { useNavigate } from 'react-router-dom';
 
 const LOGIN_INITIAL_VALUES = {
   id: '',
@@ -32,7 +32,7 @@ const LOGIN_VALIDATORS = {
 
 export default function Login() {
   const theme = useAppTheme();
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
 
   const {
     authValue: loginValue,
@@ -69,7 +69,7 @@ export default function Login() {
           <p>비밀번호를 잊으셨나요?</p>
           <p>
             계정이 없으신가요?
-            <strong onClick={() => navigate('/' + ROUTES.SIGN_UP)}>
+            <strong onClick={() => goPath('/' + ROUTES.SIGN_UP)}>
               회원가입하기
             </strong>
           </p>

--- a/frontend/src/domains/admin/Login/hooks/useLogin.ts
+++ b/frontend/src/domains/admin/Login/hooks/useLogin.ts
@@ -2,8 +2,8 @@ import { AdminAuthResponse, postAdminLogin } from '@/apis/admin.api';
 import { ApiError } from '@/apis/apiClient';
 import { ADMIN_BASE, ROUTES } from '@/constants/routes';
 import { useErrorModalContext } from '@/contexts/useErrorModal';
+import useNavigation from '@/domains/hooks/useNavigation';
 import { setLocalStorage } from '@/utils/localStorage';
-import { useNavigate } from 'react-router-dom';
 
 interface UseLoginProps {
   loginValue: {
@@ -13,7 +13,7 @@ interface UseLoginProps {
 }
 
 export default function useLogin({ loginValue }: UseLoginProps) {
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const { showErrorModal } = useErrorModalContext();
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -27,7 +27,7 @@ export default function useLogin({ loginValue }: UseLoginProps) {
         password: loginValue.password,
         onSuccess: (response: AdminAuthResponse) => {
           setLocalStorage('auth', response.data);
-          navigate(ADMIN_BASE + ROUTES.ADMIN_HOME);
+          goPath(ADMIN_BASE + ROUTES.ADMIN_HOME);
         },
       });
     } catch (error: ApiError | unknown) {

--- a/frontend/src/domains/admin/Settings/hooks/useLogout.ts
+++ b/frontend/src/domains/admin/Settings/hooks/useLogout.ts
@@ -1,11 +1,11 @@
 import { postAdminLogout } from '@/apis/admin.api';
 import { useErrorModalContext } from '@/contexts/useErrorModal';
+import useNavigation from '@/domains/hooks/useNavigation';
 import { resetLocalStorage } from '@/utils/localStorage';
-import { useNavigate } from 'react-router-dom';
 
 export function useLogout() {
   const { showErrorModal } = useErrorModalContext();
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
 
   const handleLogout = async () => {
     try {
@@ -14,7 +14,7 @@ export function useLogout() {
         throw new Error('로그아웃 실패');
       }
       resetLocalStorage('auth');
-      navigate('/login');
+      goPath('/login');
     } catch (e) {
       showErrorModal(e, '에러');
     }

--- a/frontend/src/domains/admin/SignUp/SignUp.tsx
+++ b/frontend/src/domains/admin/SignUp/SignUp.tsx
@@ -20,9 +20,9 @@ import {
   validatePassword,
 } from '@/domains/admin/utils/authValidations';
 import Toast from '@/domains/components/Toast/Toast';
+import useNavigation from '@/domains/hooks/useNavigation';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 type SignUpFieldName = 'name' | 'id' | 'password';
 
@@ -40,7 +40,7 @@ const SIGNUP_VALIDATORS = {
 
 export default function SignUp() {
   const theme = useAppTheme();
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const [toast, setToast] = useState<string | null>(null);
 
   const {
@@ -110,7 +110,7 @@ export default function SignUp() {
         <div css={signUpCaptionContainer(theme)}>
           <p>
             이미 계정이 있으신가요?
-            <strong onClick={() => navigate('/' + ROUTES.LOGIN)}>
+            <strong onClick={() => goPath('/' + ROUTES.LOGIN)}>
               로그인하기
             </strong>
           </p>

--- a/frontend/src/domains/admin/SignUp/hooks/useSignup.ts
+++ b/frontend/src/domains/admin/SignUp/hooks/useSignup.ts
@@ -2,9 +2,9 @@ import { AdminAuthResponse, postAdminSignup } from '@/apis/admin.api';
 import { ApiError } from '@/apis/apiClient';
 import { ADMIN_BASE, ROUTES } from '@/constants/routes';
 import { useErrorModalContext } from '@/contexts/useErrorModal';
+import useNavigation from '@/domains/hooks/useNavigation';
 import { setLocalStorage } from '@/utils/localStorage';
 import { FormEvent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 interface UseSignupProps {
   confirmPasswordErrors: string;
@@ -25,7 +25,7 @@ export default function useSignup({
   signUpValue,
   setToast,
 }: UseSignupProps) {
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const { showErrorModal } = useErrorModalContext();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -48,7 +48,7 @@ export default function useSignup({
         adminName: signUpValue.name,
         onSuccess: (response: AdminAuthResponse) => {
           setLocalStorage('auth', response.data);
-          navigate(ADMIN_BASE + ROUTES.ADMIN_HOME);
+          goPath(ADMIN_BASE + ROUTES.ADMIN_HOME);
         },
       });
     } catch (error) {

--- a/frontend/src/domains/hooks/useNavigation.ts
+++ b/frontend/src/domains/hooks/useNavigation.ts
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function useNavigation() {
+  const navigate = useNavigate();
+
+  const goBack = () => {
+    navigate(-1);
+  };
+
+  const goPath = (path: string) => {
+    navigate(path);
+  };
+
+  return {
+    goBack,
+    goPath,
+  };
+}

--- a/frontend/src/domains/user/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/domains/user/FeedbackPage/FeedbackPage.tsx
@@ -16,12 +16,12 @@ import FeedbackInput from '@/domains/user/home/components/FeedbackInput/Feedback
 import { useFeedbackForm } from '@/domains/user/home/hooks/useFeedbackForm';
 import { skipIcon } from '@/domains/user/OnBoarding/OnBoarding.styles';
 import { useAppTheme } from '@/hooks/useAppTheme';
-import { useNavigate } from 'react-router-dom';
 import useFeedbackSubmit from './hooks/useFeedbackSubmit';
 import TimeDelayModal from '@/components/TimeDelayModal/TimeDelayModal';
 import { Analytics, suggestionFormEvents } from '@/analytics';
 import { CategoryType } from '@/analytics/types';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 interface FeedbackPageProps {
   category: CategoryType | null;
@@ -33,7 +33,7 @@ export default function FeedbackPage({
   category,
 }: FeedbackPageProps) {
   const theme = useAppTheme();
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { organizationId } = useOrganizationId();
 
@@ -56,7 +56,7 @@ export default function FeedbackPage({
 
     Analytics.track(suggestionFormEvents.viewSuggestionsFromForm());
 
-    navigate(`/${organizationId}/dashboard`);
+    goPath(`/${organizationId}/dashboard`);
   };
 
   const handleRandomChangeWithTracking = () => {
@@ -75,10 +75,10 @@ export default function FeedbackPage({
     (isError: boolean) => {
       setIsModalOpen(false);
       if (!isError) {
-        navigate(`/${organizationId}/dashboard`);
+        goPath(`/${organizationId}/dashboard`);
       }
     },
-    [navigate]
+    [goPath]
   );
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/frontend/src/domains/user/FeedbackPage/hooks/useFeedbackSubmit.ts
+++ b/frontend/src/domains/user/FeedbackPage/hooks/useFeedbackSubmit.ts
@@ -3,7 +3,6 @@ import { SuggestionFeedback } from '@/types/feedback.types';
 import { getLocalStorage, setLocalStorage } from '@/utils/localStorage';
 import { useCallback, useState } from 'react';
 import { StatusType } from '@/types/status.types';
-import { useNavigate } from 'react-router-dom';
 import { CategoryType } from '@/analytics/types';
 
 interface FeedbackSubmitParams {
@@ -15,7 +14,6 @@ interface FeedbackSubmitParams {
 }
 
 export default function useFeedbackSubmit() {
-  const navigate = useNavigate();
   const [submitStatus, setSubmitStatus] = useState<StatusType>('idle');
 
   const submitFeedback = useCallback(
@@ -54,7 +52,7 @@ export default function useFeedbackSubmit() {
         setSubmitStatus('error');
       }
     },
-    [navigate, submitStatus]
+    [submitStatus]
   );
 
   const resetStatus = useCallback(() => {

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
@@ -13,10 +13,10 @@ import {
   skipIcon,
 } from '@/domains/user/OnBoarding/OnBoarding.styles';
 import { useAppTheme } from '@/hooks/useAppTheme';
-import { useNavigate } from 'react-router-dom';
 import { Analytics, onboardingEvents } from '@/analytics';
 import { CategoryType } from '@/analytics/types';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 interface OnBoardingProps {
   onCategoryClick: (newCategory: CategoryType) => void;
@@ -24,7 +24,7 @@ interface OnBoardingProps {
 
 export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
   const theme = useAppTheme();
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const { organizationId } = useOrganizationId();
 
   const { groupName } = useOrganizationName({
@@ -34,7 +34,7 @@ export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
   const handleViewSuggestionsClick = () => {
     Analytics.track(onboardingEvents.viewSuggestionsFromOnboarding());
 
-    navigate(`/${organizationId}/dashboard`);
+    goPath(`/${organizationId}/dashboard`);
   };
 
   return (

--- a/frontend/src/domains/user/userDashboard/UserDashboard.tsx
+++ b/frontend/src/domains/user/userDashboard/UserDashboard.tsx
@@ -24,16 +24,16 @@ import {
   FeedbackFilterType,
 } from '@/types/feedback.types';
 import { getLocalStorage } from '@/utils/localStorage';
-import { useNavigate } from 'react-router-dom';
 import FeedbackStatusMessage from './components/FeedbackStatusMessage/FeedbackStatusMessage';
 import { createFeedbacksUrl } from '@/domains/utils/createFeedbacksUrl';
 import useCursorInfiniteScroll from '@/hooks/useCursorInfiniteScroll';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
+import useNavigation from '@/domains/hooks/useNavigation';
 
 export default function UserDashboard() {
   const { organizationId } = useOrganizationId();
   const likedFeedbackIds = getLocalStorage<number[]>('feedbackIds') || [];
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const theme = useAppTheme();
 
   const {
@@ -75,7 +75,7 @@ export default function UserDashboard() {
 
   const handleNavigateToOnboarding = () => {
     Analytics.track(userDashboardEvents.viewSuggestionsFromDashboard());
-    navigate('/');
+    goPath('/');
   };
 
   const getFeedbackIsLike = (feedbackId: number) => {

--- a/frontend/src/hooks/useApiErrorHandler.ts
+++ b/frontend/src/hooks/useApiErrorHandler.ts
@@ -1,17 +1,17 @@
 import { ApiError } from '@/apis/apiClient';
 import { useErrorModalContext } from '@/contexts/useErrorModal';
+import useNavigation from '@/domains/hooks/useNavigation';
 import { resetLocalStorage } from '@/utils/localStorage';
-import { useNavigate } from 'react-router-dom';
 
 export function useApiErrorHandler() {
-  const navigate = useNavigate();
+  const { goPath } = useNavigation();
   const { showErrorModal } = useErrorModalContext();
 
   const handleApiError = async (error: ApiError) => {
     if (error.status === 401) {
       resetLocalStorage('auth');
       showErrorModal(error, '로그인 권한 없음');
-      navigate('/login');
+      goPath('/login');
     }
   };
 


### PR DESCRIPTION
## 😉 연관 이슈
close #440 

## 🚀 작업 내용
- useNavigation 커스텀 훅으로 분리하기

## 💬 리뷰 중점사항
1. useNavigation으로 분리한 이유
- `navigate(-1)` 같은 숫자 기반 호출을 `goBack()` 같은 명확한 함수 이름으로 사용하여 가독성 상승
2. 나중에 react-router-dom의 API가 바뀌거나 다른 라우팅 라이브러리(Next.js router, TanStack Router)로 교체할 때, useNavigation 훅 내부만 수정하면 되고, 실제 사용처는 그대로 유지할 수 있음.