### PR TITLE
[FE] fix: 관리자 대시보드에서 바텀 내비 제거

### DIFF
--- a/frontend/src/constants/layoutConfig.ts
+++ b/frontend/src/constants/layoutConfig.ts
@@ -27,7 +27,7 @@ export const LAYOUT_CONFIGS: Record<string, LayoutConfig> = {
       showBackButton: true,
     },
     bottomNav: {
-      show: true,
+      show: false,
     },
   },
   [`${ROUTES.ADMIN}/${ROUTES.ADMIN_SETTINGS}`]: {


### PR DESCRIPTION
## 😉 연관 이슈
#608 

## 🚀 작업 내용
관리자 대시보드 페이지에서 바텀 내비게이션 제거했습니다!
<img width="548" height="947" alt="image" src="https://github.com/user-attachments/assets/b6c261b1-53a2-4f9f-a1cc-49fbbd7a27a8" />


