### PR TITLE
[FE] fix: 사용자 submit 페이지 카테고리 하드코딩 수정

### DIFF
--- a/frontend/src/analytics/events/onboarding.ts
+++ b/frontend/src/analytics/events/onboarding.ts
@@ -1,12 +1,13 @@
-import { BaseEvent, CategoryType } from '../types';
+import { CategoryListType } from '@/constants/categoryList';
+import { BaseEvent } from '../types';
 
 interface OnboardingEventFactory {
-  categorySelect: (category: CategoryType) => BaseEvent;
+  categorySelect: (category: CategoryListType) => BaseEvent;
   viewSuggestionsFromOnboarding: () => BaseEvent;
 }
 
 export const onboardingEvents: OnboardingEventFactory = {
-  categorySelect: (category: CategoryType): BaseEvent => ({
+  categorySelect: (category: CategoryListType): BaseEvent => ({
     name: 'category_select',
     parameters: {
       event_category: 'onboarding',

--- a/frontend/src/analytics/types.ts
+++ b/frontend/src/analytics/types.ts
@@ -7,5 +7,3 @@ export interface BaseEvent {
     [key: string]: string | number | boolean | undefined;
   };
 }
-
-export type CategoryType = '신고' | '질문' | '건의' | '기타';

--- a/frontend/src/apis/adminOrganization.api.ts
+++ b/frontend/src/apis/adminOrganization.api.ts
@@ -1,4 +1,4 @@
-import { CategoryType } from '@/analytics/types';
+import { CategoryListType } from './../constants/categoryList';
 import { apiClient } from '@/apis/apiClient';
 import { ApiResponse } from '@/types/apiResponse';
 
@@ -13,7 +13,7 @@ type GetAdminOrganizationResponse = ApiResponse<AdminOrganizationType[]>;
 
 type RequestData = {
   organizationName: string;
-  categories: CategoryType[];
+  categories: CategoryListType[];
 };
 
 type AdminOrganizationUUIDType = {

--- a/frontend/src/apis/userFeedback.api.ts
+++ b/frontend/src/apis/userFeedback.api.ts
@@ -1,5 +1,5 @@
-import { CategoryType } from '@/analytics/types';
 import { apiClient } from '@/apis/apiClient';
+import { CategoryListType } from '@/constants/categoryList';
 import {
   FeedbackType,
   SortType,
@@ -11,7 +11,7 @@ interface UserFeedbackParams {
   userName: string;
   isSecret: boolean;
   content: string;
-  category: CategoryType | null;
+  category: CategoryListType | null;
   onSuccess: (data: SuggestionFeedback) => void;
   onError: () => void;
 }
@@ -26,7 +26,7 @@ interface FeedbackRequestBody {
   content: string;
   isSecret: boolean;
   userName: string;
-  category: CategoryType | null;
+  category: CategoryListType | null;
 }
 
 export async function postUserFeedback({

--- a/frontend/src/domains/admin/CreateRoomModal/CreateRoomModal.tsx
+++ b/frontend/src/domains/admin/CreateRoomModal/CreateRoomModal.tsx
@@ -1,6 +1,6 @@
-import { CategoryType } from '@/analytics/types';
 import BasicButton from '@/components/BasicButton/BasicButton';
 import Modal from '@/components/Modal/Modal';
+import { CategoryListType } from '@/constants/categoryList';
 import RoomCategoryList from '@/domains/admin/components/RoomCategoryList/RoomCategoryList';
 import RoomCategoryTagList from '@/domains/admin/components/RoomCategoryTagList/RoomCategoryTagList';
 import RoomNameInput from '@/domains/admin/components/RoomNameInput/RoomNameInput';
@@ -82,7 +82,7 @@ export default function CreateRoomModal({
               organizationName: organizationName,
               categories: selectedCategories.map(
                 (category: SelectedCategoryItem) =>
-                  category.category as CategoryType
+                  category.category as CategoryListType
               ),
             })
           }

--- a/frontend/src/domains/admin/CreateRoomModal/hooks/useCategorySelection.ts
+++ b/frontend/src/domains/admin/CreateRoomModal/hooks/useCategorySelection.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
-import { CategoryListType, CATEGORY_LIST } from '@/constants/categoryList';
+import { CategoryListType } from '@/constants/categoryList';
 import { MAX_CATEGORIES } from '@/constants/maxCategories';
+import { createCategoryIconPairs } from '@/domains/utils/createCategoryList';
 
 export interface SelectedCategoryItem {
   icon: string | React.ReactNode;
@@ -22,21 +23,7 @@ export function useCategorySelection({
     if (!initialCategories || initialCategories.length === 0) return;
 
     const initialSelectedCategories: SelectedCategoryItem[] =
-      initialCategories.reduce(
-        (acc: SelectedCategoryItem[], categoryString) => {
-          const categoryItem = CATEGORY_LIST.find(
-            (item) => item.category === categoryString
-          );
-          if (categoryItem) {
-            acc.push({
-              icon: categoryItem.icon,
-              category: categoryItem.category,
-            });
-          }
-          return acc;
-        },
-        []
-      ) as SelectedCategoryItem[];
+      createCategoryIconPairs(initialCategories);
 
     setSelectedCategories(initialSelectedCategories);
   }, [initialCategories]);

--- a/frontend/src/domains/components/FeedbackBoxHeader/FeedbackBoxHeader.tsx
+++ b/frontend/src/domains/components/FeedbackBoxHeader/FeedbackBoxHeader.tsx
@@ -1,4 +1,4 @@
-import { CategoryType } from '@/analytics/types';
+import { CategoryListType } from '@/constants/categoryList';
 import {
   headerInfoBox,
   imgContainer,
@@ -14,7 +14,7 @@ interface FeedbackBoxHeaderProps {
   feedbackId: number;
   userName?: string;
   type: FeedbackStatusType;
-  category: CategoryType;
+  category: CategoryListType;
 }
 
 export default function FeedbackBoxHeader({

--- a/frontend/src/domains/hooks/useCategoryManager.ts
+++ b/frontend/src/domains/hooks/useCategoryManager.ts
@@ -1,5 +1,5 @@
 import { Analytics, onboardingEvents } from '@/analytics';
-import { CategoryType } from '@/analytics/types';
+import { CategoryListType } from '@/constants/categoryList';
 import { useState } from 'react';
 
 interface useCategoryManagerProps {
@@ -9,8 +9,8 @@ interface useCategoryManagerProps {
 export default function useCategoryManager({
   moveNextStep,
 }: useCategoryManagerProps) {
-  const [category, setCategory] = useState<CategoryType | null>(null);
-  const handleCategoryChange = (newCategory: CategoryType) => {
+  const [category, setCategory] = useState<CategoryListType | null>(null);
+  const handleCategoryChange = (newCategory: CategoryListType) => {
     Analytics.track(onboardingEvents.categorySelect(newCategory));
 
     setCategory(newCategory);

--- a/frontend/src/domains/user/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/domains/user/FeedbackPage/FeedbackPage.tsx
@@ -19,12 +19,12 @@ import { useAppTheme } from '@/hooks/useAppTheme';
 import useFeedbackSubmit from './hooks/useFeedbackSubmit';
 import TimeDelayModal from '@/components/TimeDelayModal/TimeDelayModal';
 import { Analytics, suggestionFormEvents } from '@/analytics';
-import { CategoryType } from '@/analytics/types';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
 import useNavigation from '@/domains/hooks/useNavigation';
+import { CategoryListType } from '@/constants/categoryList';
 
 interface FeedbackPageProps {
-  category: CategoryType | null;
+  category: CategoryListType | null;
   movePrevStep: () => void;
 }
 

--- a/frontend/src/domains/user/FeedbackPage/hooks/useFeedbackSubmit.ts
+++ b/frontend/src/domains/user/FeedbackPage/hooks/useFeedbackSubmit.ts
@@ -3,13 +3,13 @@ import { SuggestionFeedback } from '@/types/feedback.types';
 import { getLocalStorage, setLocalStorage } from '@/utils/localStorage';
 import { useCallback, useState } from 'react';
 import { StatusType } from '@/types/status.types';
-import { CategoryType } from '@/analytics/types';
+import { CategoryListType } from '@/constants/categoryList';
 
 interface FeedbackSubmitParams {
   content: string;
   userName: string;
   isSecret: boolean;
-  category: CategoryType | null;
+  category: CategoryListType | null;
   organizationId: string;
 }
 

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
@@ -14,12 +14,13 @@ import {
 } from '@/domains/user/OnBoarding/OnBoarding.styles';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { Analytics, onboardingEvents } from '@/analytics';
-import { CategoryType } from '@/analytics/types';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
 import useNavigation from '@/domains/hooks/useNavigation';
+import { createCategoryIconPairs } from '@/domains/utils/createCategoryList';
+import { CategoryListType } from '@/constants/categoryList';
 
 interface OnBoardingProps {
-  onCategoryClick: (newCategory: CategoryType) => void;
+  onCategoryClick: (newCategory: CategoryListType) => void;
 }
 
 export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
@@ -27,9 +28,11 @@ export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
   const { goPath } = useNavigation();
   const { organizationId } = useOrganizationId();
 
-  const { groupName } = useOrganizationName({
+  const { groupName, categories } = useOrganizationName({
     organizationId,
   });
+
+  const categoryIconPairs = createCategoryIconPairs(categories);
 
   const handleViewSuggestionsClick = () => {
     Analytics.track(onboardingEvents.viewSuggestionsFromOnboarding());
@@ -49,26 +52,14 @@ export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
           <p css={question(theme)}>건의하고 싶은 카테고리를 선택해주세요</p>
         </div>
         <div css={buttonContainer}>
-          <CategoryButton
-            icon='🚨'
-            text='신고'
-            onClick={() => onCategoryClick('신고')}
-          />
-          <CategoryButton
-            icon='🙋‍♀️'
-            text='질문'
-            onClick={() => onCategoryClick('질문')}
-          />
-          <CategoryButton
-            icon='💬'
-            text='건의'
-            onClick={() => onCategoryClick('건의')}
-          />
-          <CategoryButton
-            icon='💡'
-            text='기타'
-            onClick={() => onCategoryClick('기타')}
-          />
+          {categoryIconPairs.map((category) => (
+            <CategoryButton
+              key={category.category}
+              icon={category.icon}
+              text={category.category}
+              onClick={() => onCategoryClick(category.category)}
+            />
+          ))}
         </div>
       </div>
       <BasicButton

--- a/frontend/src/domains/user/userDashboard/components/UserFeedbackBox/UserFeedbackBox.tsx
+++ b/frontend/src/domains/user/userDashboard/components/UserFeedbackBox/UserFeedbackBox.tsx
@@ -8,7 +8,7 @@ import { FeedbackStatusType } from '@/types/feedbackStatus.types';
 import { SerializedStyles } from '@emotion/react';
 import { secretText } from './UserFeedbackBox.styles';
 import FeedbackAnswer from '@/domains/components/FeedbackAnswer/FeedbackAnswer';
-import { CategoryType } from '@/analytics/types';
+import { CategoryListType } from '@/constants/categoryList';
 
 interface UserFeedbackBox {
   userName: string;
@@ -22,7 +22,7 @@ interface UserFeedbackBox {
   customCSS: (SerializedStyles | null)[];
   isMyFeedback: boolean;
   comment: null | string;
-  category: CategoryType;
+  category: CategoryListType;
 }
 
 export default function UserFeedbackBox({

--- a/frontend/src/domains/utils/createCategoryList.ts
+++ b/frontend/src/domains/utils/createCategoryList.ts
@@ -1,0 +1,20 @@
+import { CATEGORY_LIST, CategoryListType } from '@/constants/categoryList';
+import { SelectedCategoryItem } from '../admin/CreateRoomModal/hooks/useCategorySelection';
+
+export function createCategoryIconPairs(initialCategories: CategoryListType[]) {
+  return initialCategories.reduce(
+    (acc: SelectedCategoryItem[], categoryString) => {
+      const categoryItem = CATEGORY_LIST.find(
+        (item) => item.category === categoryString
+      );
+      if (categoryItem) {
+        acc.push({
+          icon: categoryItem.icon,
+          category: categoryItem.category,
+        });
+      }
+      return acc;
+    },
+    []
+  ) as SelectedCategoryItem[];
+}

--- a/frontend/src/types/feedback.types.ts
+++ b/frontend/src/types/feedback.types.ts
@@ -1,4 +1,4 @@
-import { CategoryType } from '@/analytics/types';
+import { CategoryListType } from '@/constants/categoryList';
 import { FeedbackStatusType } from '@/types/feedbackStatus.types';
 
 export interface FeedbackType {
@@ -10,7 +10,7 @@ export interface FeedbackType {
   userName: string;
   likeCount: number;
   comment: null | string;
-  category: CategoryType;
+  category: CategoryListType;
 }
 
 export interface FeedbackResponse<T> {


### PR DESCRIPTION
## 😉 연관 이슈
#612 

## 🚀 작업 내용
사용자 submit 페이지 카테고리 하드코딩 수정

## 💬 리뷰 중점사항
- 서버한테 카테고리 받아올 때 카테고리 이름만 받아와서 로컬에 저장되어있는 카테고리 정보랑 매칭해서 아이콘을 추가하는 로직을 유티함수로 분리했습니다!
