### PR TITLE
[BE] feat: 회원탈퇴 API 구현

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/admin/api/AdminApi.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/api/AdminApi.java
@@ -1,0 +1,33 @@
+package feedzupzup.backend.admin.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import feedzupzup.backend.admin.dto.AdminSession;
+import feedzupzup.backend.auth.presentation.annotation.AdminAuthenticationPrincipal;
+import feedzupzup.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Tag(name = "Admin", description = "관리자 API")
+public interface AdminApi {
+
+    @Operation(summary = "관리자 회원탈퇴", description = "관리자 회원탈퇴를 진행합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "회원탈퇴 성공", useReturnTypeSchema = true)
+    })
+    @SecurityRequirement(name = "SessionAuth")
+    @ResponseStatus(NO_CONTENT)
+    @DeleteMapping("/admin")
+    SuccessResponse<Void> withdraw(
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) @AdminAuthenticationPrincipal AdminSession adminSession
+    );
+}

--- a/backend/src/main/java/feedzupzup/backend/admin/application/AdminService.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/application/AdminService.java
@@ -1,0 +1,25 @@
+package feedzupzup.backend.admin.application;
+
+import feedzupzup.backend.admin.domain.AdminRepository;
+import feedzupzup.backend.notification.application.NotificationService;
+import feedzupzup.backend.organizer.application.OrganizerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final NotificationService notificationService;
+    private final OrganizerService organizerService;
+
+    @Transactional
+    public void withdraw(final Long adminId) {
+        notificationService.deleteAllByAdminId(adminId);
+        organizerService.deleteAllByAdminId(adminId);
+        adminRepository.deleteById(adminId);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/admin/controller/AdminController.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/controller/AdminController.java
@@ -1,0 +1,26 @@
+package feedzupzup.backend.admin.controller;
+
+import feedzupzup.backend.admin.api.AdminApi;
+import feedzupzup.backend.admin.application.AdminService;
+import feedzupzup.backend.admin.dto.AdminSession;
+import feedzupzup.backend.auth.presentation.session.HttpSessionManager;
+import feedzupzup.backend.global.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminController implements AdminApi {
+
+    private final AdminService adminService;
+    private final HttpSessionManager httpSessionManager;
+
+    @Override
+    public SuccessResponse<Void> withdraw(final HttpServletRequest httpRequest, final AdminSession adminSession) {
+        httpSessionManager.removeAdminSession(httpRequest);
+        adminService.withdraw(adminSession.adminId());
+        return SuccessResponse.success(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/admin/domain/Admin.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/domain/Admin.java
@@ -10,14 +10,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE admin SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Admin extends BaseTimeEntity {
 
     @Id
@@ -38,6 +43,9 @@ public class Admin extends BaseTimeEntity {
 
     @Column(nullable = false)
     private boolean alertsOn;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public Admin(@NonNull final LoginId loginId, @NonNull final EncodedPassword password, @NonNull final AdminName adminName) {
         this.loginId = loginId;

--- a/backend/src/main/java/feedzupzup/backend/category/application/OrganizationCategoryService.java
+++ b/backend/src/main/java/feedzupzup/backend/category/application/OrganizationCategoryService.java
@@ -1,0 +1,27 @@
+package feedzupzup.backend.category.application;
+
+import feedzupzup.backend.category.domain.OrganizationCategory;
+import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class OrganizationCategoryService {
+
+    private final OrganizationCategoryRepository organizationCategoryRepository;
+
+    @Transactional
+    public void deleteAllByOrganizationIds(final List<Long> organizationIds) {
+        organizationCategoryRepository.deleteAllByOrganizationIdIn(organizationIds);
+    }
+
+    @Transactional
+    public void saveAll(final Set<OrganizationCategory> organizationCategories) {
+        organizationCategoryRepository.saveAll(organizationCategories);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/category/domain/OrganizationCategoryRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/category/domain/OrganizationCategoryRepository.java
@@ -1,9 +1,12 @@
 package feedzupzup.backend.category.domain;
 
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrganizationCategoryRepository extends JpaRepository<OrganizationCategory, Long> {
 
+    void deleteAllByOrganizationIdIn(Collection<Long> organizationIds);
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
@@ -108,4 +108,9 @@ public class AdminFeedbackService {
 
         return new FeedbackStatisticResponse(confirmedCount, totalCount, reflectionRate);
     }
+
+    @Transactional
+    public void deleteAllByOrganizationIds(final List<Long> organizationIds) {
+        feedBackRepository.deleteAllByOrganizationIdIn(organizationIds);
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/FeedbackRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/FeedbackRepository.java
@@ -90,4 +90,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
             WHERE org.admin.id = :adminId AND f.deletedAt IS NULL
             """)
     FeedbackAmount findFeedbackStatisticsByAdminId(Long adminId);
+
+    void deleteAllByOrganizationIdIn(List<Long> organizationIds);
 }

--- a/backend/src/main/java/feedzupzup/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/feedzupzup/backend/notification/application/NotificationService.java
@@ -24,7 +24,7 @@ public class NotificationService {
 
     @Transactional
     public void registerToken(final NotificationTokenRequest request, final Long adminId) {
-        notificationTokenRepository.findByAdminId(adminId)
+        notificationTokenRepository.findByAdmin_Id(adminId)
                 .ifPresentOrElse(
                         existingToken -> updateExistingToken(existingToken, request.notificationToken()),
                         () -> createNewToken(request, adminId)
@@ -40,6 +40,11 @@ public class NotificationService {
     public void updateAlertsSetting(final UpdateAlertsSettingRequest request, final Long adminId) {
         final Admin admin = getAdminById(adminId);
         admin.updateAlertsSetting(request.alertsOn());
+    }
+
+    @Transactional
+    public void deleteAllByAdminId(final Long adminId) {
+        notificationTokenRepository.deleteAllByAdmin_Id(adminId);
     }
 
     private Admin getAdminById(Long adminId) {

--- a/backend/src/main/java/feedzupzup/backend/notification/domain/NotificationTokenRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/notification/domain/NotificationTokenRepository.java
@@ -7,9 +7,9 @@ import java.util.Optional;
 
 public interface NotificationTokenRepository extends JpaRepository<NotificationToken, Long> {
 
-    boolean existsByAdminId(Long adminId);
+    Optional<NotificationToken> findByAdmin_Id(Long adminId);
     
-    Optional<NotificationToken> findByAdminId(Long adminId);
-    
-    void deleteAllByAdminIdIn(List<Long> adminIds);
+    void deleteAllByAdmin_IdIn(List<Long> adminIds);
+
+    void deleteAllByAdmin_Id(Long adminId);
 }

--- a/backend/src/main/java/feedzupzup/backend/notification/infrastructure/FcmErrorHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/notification/infrastructure/FcmErrorHandler.java
@@ -60,7 +60,7 @@ public class FcmErrorHandler {
 
         if (!deletableAdminIds.isEmpty()) {
             log.info("토큰 삭제 adminId : {}", deletableAdminIds);
-            notificationTokenRepository.deleteAllByAdminIdIn(deletableAdminIds);
+            notificationTokenRepository.deleteAllByAdmin_IdIn(deletableAdminIds);
         }
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/notification/infrastructure/FcmPushNotifier.java
+++ b/backend/src/main/java/feedzupzup/backend/notification/infrastructure/FcmPushNotifier.java
@@ -42,7 +42,7 @@ public class FcmPushNotifier implements PushNotifier {
         
         for (NotificationPayload payload : payloads) {
             log.info("adminId: {}", payload.adminId());
-            Optional<NotificationToken> tokenOpt = notificationTokenRepository.findByAdminId(payload.adminId());
+            Optional<NotificationToken> tokenOpt = notificationTokenRepository.findByAdmin_Id(payload.adminId());
             if (tokenOpt.isPresent()) {
                 log.info("tokenOpt: {}", tokenOpt.get().getRegistrationToken());
                 validPayloads.add(payload);

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -2,8 +2,8 @@ package feedzupzup.backend.organization.application;
 
 import feedzupzup.backend.admin.domain.Admin;
 import feedzupzup.backend.admin.domain.AdminRepository;
-import feedzupzup.backend.auth.exception.AuthException.ForbiddenException;
-import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
+import feedzupzup.backend.category.application.OrganizationCategoryService;
+import feedzupzup.backend.feedback.application.AdminFeedbackService;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.AdminOrganizationInfo;
 import feedzupzup.backend.organization.domain.Organization;
@@ -17,6 +17,7 @@ import feedzupzup.backend.organization.event.OrganizationCreatedEvent;
 import feedzupzup.backend.organizer.domain.Organizer;
 import feedzupzup.backend.organizer.domain.OrganizerRepository;
 import feedzupzup.backend.organizer.domain.OrganizerRole;
+import feedzupzup.backend.qr.service.QRService;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -33,8 +34,10 @@ public class AdminOrganizationService {
     private final OrganizationRepository organizationRepository;
     private final OrganizerRepository organizerRepository;
     private final AdminRepository adminRepository;
-    private final OrganizationCategoryRepository organizationCategoryRepository;
+    private final OrganizationCategoryService organizationCategoryService;
     private final ApplicationEventPublisher eventPublisher;
+    private final AdminFeedbackService adminFeedbackService;
+    private final QRService qrService;
 
     @Transactional
     public AdminCreateOrganizationResponse createOrganization(
@@ -50,7 +53,7 @@ public class AdminOrganizationService {
 
         final Admin admin = findAdminBy(adminId);
         final Organizer organizer = new Organizer(
-                organization,
+                savedOrganization,
                 admin,
                 OrganizerRole.OWNER
         );
@@ -80,7 +83,7 @@ public class AdminOrganizationService {
             final Set<String> categories,
             final Organization organization
     ) {
-        organizationCategoryRepository.saveAll(organization.getOrganizationCategories().getOrganizationCategories());
+        organizationCategoryService.saveAll(organization.getOrganizationCategories().getOrganizationCategories());
         organization.addOrganizationCategories(categories);
     }
 
@@ -95,5 +98,13 @@ public class AdminOrganizationService {
         final Set<String> categories = request.categories();
         organization.updateOrganizationCategoriesAndName(categories, request.organizationName());
         return AdminUpdateOrganizationResponse.from(organization);
+    }
+
+    @Transactional
+    public void deleteAllByOrganizerIds(final List<Long> organizationIds) {
+        organizationCategoryService.deleteAllByOrganizationIds(organizationIds);
+        adminFeedbackService.deleteAllByOrganizationIds(organizationIds);
+        qrService.deleteAllByOrganizationIds(organizationIds);
+        organizationRepository.deleteAllById(organizationIds);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrganizationCategories {
 
-    @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "organization", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private final Set<OrganizationCategory> organizationCategories = new HashSet<>();
 
     public void addAll(final Set<String> categories, final Organization organization) {

--- a/backend/src/main/java/feedzupzup/backend/organizer/application/OrganizerService.java
+++ b/backend/src/main/java/feedzupzup/backend/organizer/application/OrganizerService.java
@@ -1,0 +1,28 @@
+package feedzupzup.backend.organizer.application;
+
+import feedzupzup.backend.organization.application.AdminOrganizationService;
+import feedzupzup.backend.organizer.domain.Organizer;
+import feedzupzup.backend.organizer.domain.OrganizerRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class OrganizerService {
+
+    private final OrganizerRepository organizerRepository;
+    private final AdminOrganizationService adminOrganizationService;
+
+    @Transactional
+    public void deleteAllByAdminId(final Long adminId) {
+        List<Organizer> organizers = organizerRepository.findAllFetchedByAdminId(adminId);
+        List<Long> organizationIds = organizers.stream()
+                .map(organizer -> organizer.getOrganization().getId())
+                .toList();
+        organizerRepository.deleteAllByAdmin_Id(adminId);
+        adminOrganizationService.deleteAllByOrganizerIds(organizationIds);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
@@ -15,4 +15,8 @@ public interface OrganizerRepository extends JpaRepository<Organizer, Long> {
 
     boolean existsOrganizerByAdmin_IdAndOrganization_Uuid(Long adminId, UUID organizationUuid);
 
+    void deleteAllByAdmin_Id(Long adminId);
+
+    @Query("SELECT o FROM Organizer o JOIN FETCH o.organization WHERE o.admin.id = :adminId")
+    List<Organizer> findAllFetchedByAdminId(Long adminId);
 }

--- a/backend/src/main/java/feedzupzup/backend/qr/repository/QRRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/qr/repository/QRRepository.java
@@ -1,6 +1,7 @@
 package feedzupzup.backend.qr.repository;
 
 import feedzupzup.backend.qr.domain.QR;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface QRRepository extends JpaRepository<QR, Long> {
     Optional<QR> findByOrganizationId(Long organizationId);
 
     boolean existsByOrganizationId(Long id);
+
+    void deleteAllByOrganizationIdIn(List<Long> organizationIds);
 }

--- a/backend/src/main/java/feedzupzup/backend/qr/service/QRService.java
+++ b/backend/src/main/java/feedzupzup/backend/qr/service/QRService.java
@@ -13,6 +13,7 @@ import feedzupzup.backend.qr.dto.response.QRResponse;
 import feedzupzup.backend.qr.repository.QRRepository;
 import feedzupzup.backend.s3.service.S3PresignedDownloadService;
 import feedzupzup.backend.s3.service.S3UploadService;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -85,5 +86,10 @@ public class QRService {
         return qrRepository.findByOrganizationId(organization.getId())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "해당 ID(id = " + organization.getUuid() + ")인 단체의 QR 코드를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public void deleteAllByOrganizationIds(final List<Long> organizationIds) {
+        qrRepository.deleteAllByOrganizationIdIn(organizationIds);
     }
 }

--- a/backend/src/main/resources/db/migration/V22__add_soft_delete_admin.sql
+++ b/backend/src/main/resources/db/migration/V22__add_soft_delete_admin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE admin
+    ADD COLUMN deleted_at DATETIME NULL;

--- a/backend/src/test/java/feedzupzup/backend/admin/application/AdminServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/admin/application/AdminServiceTest.java
@@ -1,0 +1,62 @@
+package feedzupzup.backend.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feedzupzup.backend.admin.domain.Admin;
+import feedzupzup.backend.admin.domain.AdminRepository;
+import feedzupzup.backend.admin.domain.fixture.AdminFixture;
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.notification.domain.NotificationToken;
+import feedzupzup.backend.notification.domain.NotificationTokenRepository;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import feedzupzup.backend.organizer.domain.Organizer;
+import feedzupzup.backend.organizer.domain.OrganizerRepository;
+import feedzupzup.backend.organizer.domain.OrganizerRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AdminServiceTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private NotificationTokenRepository notificationTokenRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizerRepository organizerRepository;
+
+    @Test
+    @DisplayName("관리자 회원탈퇴시 관련 모든 데이터가 삭제된다")
+    void withdraw_success() {
+        // given
+        Admin admin = AdminFixture.create();
+        adminRepository.save(admin);
+
+        NotificationToken notificationToken = new NotificationToken(admin, "test-token");
+        notificationTokenRepository.save(notificationToken);
+
+        Organization organization = OrganizationFixture.createAllBlackBox();
+        Organization savedOrganization = organizationRepository.save(organization);
+
+        Organizer organizer = new Organizer(savedOrganization, admin, OrganizerRole.OWNER);
+        organizerRepository.save(organizer);
+
+        // when
+        adminService.withdraw(admin.getId());
+
+        // then
+        assertThat(adminRepository.findById(admin.getId())).isEmpty();
+        assertThat(notificationTokenRepository.findByAdmin_Id(admin.getId())).isEmpty();
+        assertThat(organizerRepository.findAllFetchedByAdminId(admin.getId())).isEmpty();
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/admin/controller/AdminControllerE2ETest.java
+++ b/backend/src/test/java/feedzupzup/backend/admin/controller/AdminControllerE2ETest.java
@@ -1,0 +1,96 @@
+package feedzupzup.backend.admin.controller;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import feedzupzup.backend.admin.domain.Admin;
+import feedzupzup.backend.admin.domain.AdminRepository;
+import feedzupzup.backend.admin.domain.vo.AdminName;
+import feedzupzup.backend.admin.domain.vo.EncodedPassword;
+import feedzupzup.backend.admin.domain.vo.LoginId;
+import feedzupzup.backend.admin.domain.vo.Password;
+import feedzupzup.backend.auth.application.PasswordEncoder;
+import feedzupzup.backend.auth.dto.request.LoginRequest;
+import feedzupzup.backend.config.E2EHelper;
+import feedzupzup.backend.notification.domain.NotificationToken;
+import feedzupzup.backend.notification.domain.NotificationTokenRepository;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import feedzupzup.backend.organizer.domain.Organizer;
+import feedzupzup.backend.organizer.domain.OrganizerRepository;
+import feedzupzup.backend.organizer.domain.OrganizerRole;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class AdminControllerE2ETest extends E2EHelper {
+
+    private static final String SESSION_ID = "JSESSIONID";
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private NotificationTokenRepository notificationTokenRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizerRepository organizerRepository;
+
+    @Test
+    @DisplayName("관리자가 회원탈퇴를 성공적으로 수행한다")
+    void withdraw_success() {
+        // given
+        Password password = new Password("password123");
+        Admin admin = new Admin(new LoginId("testAdmin"), passwordEncoder.encode(password), new AdminName("testName"));
+        adminRepository.save(admin);
+
+        NotificationToken notificationToken = new NotificationToken(admin, "test-token");
+        notificationTokenRepository.save(notificationToken);
+
+        Organization organization = OrganizationFixture.createAllBlackBox();
+        Organization saved = organizationRepository.save(organization);
+
+        Organizer organizer = new Organizer(saved, admin, OrganizerRole.OWNER);
+        organizerRepository.save(organizer);
+
+        LoginRequest loginRequest = new LoginRequest("testAdmin", "password123");
+        String sessionCookie = given()
+                .contentType(ContentType.JSON)
+                .body(loginRequest)
+        .when()
+                .post("/admin/login")
+        .then()
+                .extract()
+                .cookie(SESSION_ID);
+
+        // when & then
+        given()
+                .cookie(SESSION_ID, sessionCookie)
+        .when()
+                .delete("/admin")
+        .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 상태에서 회원탈퇴 요청시 401 에러가 발생한다")
+    void withdraw_unauthorized() {
+        // when & then
+        given()
+        .when()
+                .delete("/admin")
+        .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("status", equalTo(401))
+                .body("code", equalTo("A04"));
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/category/application/OrganizationCategoryServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/category/application/OrganizationCategoryServiceTest.java
@@ -1,0 +1,86 @@
+package feedzupzup.backend.category.application;
+
+import static feedzupzup.backend.category.domain.Category.SUGGESTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import feedzupzup.backend.category.domain.OrganizationCategory;
+import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
+import feedzupzup.backend.category.fixture.OrganizationCategoryFixture;
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OrganizationCategoryServiceTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private OrganizationCategoryService organizationCategoryService;
+
+    @Autowired
+    private OrganizationCategoryRepository organizationCategoryRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Test
+    @DisplayName("여러 단체 ID로 카테고리들을 일괄 삭제한다")
+    void deleteAllByOrganizationIds_success() {
+        // given
+        Organization organization1 = OrganizationFixture.createAllBlackBox();
+        Organization organization2 = OrganizationFixture.createAllBlackBox();
+        Organization organization3 = OrganizationFixture.createAllBlackBox();
+        
+        organizationRepository.save(organization1);
+        organizationRepository.save(organization2);
+        organizationRepository.save(organization3);
+
+        OrganizationCategory category1 = OrganizationCategoryFixture.createOrganizationCategory(organization1, SUGGESTION);
+        OrganizationCategory category2 = OrganizationCategoryFixture.createOrganizationCategory(organization2, SUGGESTION);
+        OrganizationCategory category3 = OrganizationCategoryFixture.createOrganizationCategory(organization3, SUGGESTION);
+        
+        organizationCategoryRepository.save(category1);
+        organizationCategoryRepository.save(category2);
+        organizationCategoryRepository.save(category3);
+
+        List<Long> organizationIds = List.of(organization1.getId(), organization2.getId());
+
+        // when
+        organizationCategoryService.deleteAllByOrganizationIds(organizationIds);
+
+        // then
+        List<OrganizationCategory> remainingCategories = organizationCategoryRepository.findAll();
+        assertAll(
+                () -> assertThat(remainingCategories).hasSize(1),
+                () -> assertThat(remainingCategories.get(0).getOrganization().getId()).isEqualTo(organization3.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리들을 일괄 저장한다")
+    void saveAll_success() {
+        // given
+        Organization organization1 = OrganizationFixture.createAllBlackBox();
+        Organization organization2 = OrganizationFixture.createAllBlackBox();
+        
+        organizationRepository.save(organization1);
+        organizationRepository.save(organization2);
+
+        OrganizationCategory category1 = OrganizationCategoryFixture.createOrganizationCategory(organization1, SUGGESTION);
+        OrganizationCategory category2 = OrganizationCategoryFixture.createOrganizationCategory(organization2, SUGGESTION);
+        
+        Set<OrganizationCategory> categories = Set.of(category1, category2);
+
+        // when
+        organizationCategoryService.saveAll(categories);
+
+        // then
+        List<OrganizationCategory> savedCategories = organizationCategoryRepository.findAll();
+        assertThat(savedCategories).hasSize(2);
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/notification/infrastructure/FcmErrorHandlerTest.java
+++ b/backend/src/test/java/feedzupzup/backend/notification/infrastructure/FcmErrorHandlerTest.java
@@ -57,7 +57,7 @@ class FcmErrorHandlerTest extends ServiceIntegrationHelper {
         fcmErrorHandler.handleFailures(batchResponse, adminIds);
 
         // then
-        assertThat(notificationTokenRepository.findByAdminId(admin.getId())).isEmpty();
+        assertThat(notificationTokenRepository.findByAdmin_Id(admin.getId())).isEmpty();
     }
 
     @Test
@@ -80,7 +80,7 @@ class FcmErrorHandlerTest extends ServiceIntegrationHelper {
         fcmErrorHandler.handleFailures(batchResponse, adminIds);
 
         // then
-        assertThat(notificationTokenRepository.findByAdminId(admin.getId())).isPresent();
+        assertThat(notificationTokenRepository.findByAdmin_Id(admin.getId())).isPresent();
     }
 
     private Admin createAndSaveAdmin(String adminName, String loginId) {

--- a/backend/src/test/java/feedzupzup/backend/organizer/application/OrganizerServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organizer/application/OrganizerServiceTest.java
@@ -1,0 +1,82 @@
+package feedzupzup.backend.organizer.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.verify;
+
+import feedzupzup.backend.admin.domain.Admin;
+import feedzupzup.backend.admin.domain.AdminRepository;
+import feedzupzup.backend.admin.domain.fixture.AdminFixture;
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.organization.application.AdminOrganizationService;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import feedzupzup.backend.organizer.domain.Organizer;
+import feedzupzup.backend.organizer.domain.OrganizerRepository;
+import feedzupzup.backend.organizer.domain.OrganizerRole;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+class OrganizerServiceTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private OrganizerService organizerService;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizerRepository organizerRepository;
+
+    @Autowired
+    private AdminOrganizationService adminOrganizationService;
+
+    @Test
+    @DisplayName("관리자 ID로 오거나이저들을 삭제하면서 연관된 조직 데이터도 정리한다")
+    void deleteAllByAdminId_success() {
+        // given
+        Admin admin = AdminFixture.create();
+        adminRepository.save(admin);
+
+        Organization organization1 = OrganizationFixture.createAllBlackBox();
+        Organization organization2 = OrganizationFixture.createAllBlackBox();
+        Organization save1 = organizationRepository.save(organization1);
+        Organization save2 = organizationRepository.save(organization2);
+
+        Organizer organizer1 = new Organizer(save1, admin, OrganizerRole.OWNER);
+        Organizer organizer2 = new Organizer(save2, admin, OrganizerRole.OWNER);
+        organizerRepository.save(organizer1);
+        organizerRepository.save(organizer2);
+
+        // when
+        organizerService.deleteAllByAdminId(admin.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(organizerRepository.findAllFetchedByAdminId(admin.getId())).isEmpty()
+        );
+    }
+
+    @Test
+    @DisplayName("관리자에게 연관된 오거나이저가 없는 경우 정상적으로 처리한다")
+    void deleteAllByAdminId_noOrganizers() {
+        // given
+        Admin admin = AdminFixture.create();
+        adminRepository.save(admin);
+
+        // when
+        organizerService.deleteAllByAdminId(admin.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(organizerRepository.findAllFetchedByAdminId(admin.getId())).isEmpty()
+        );
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/organizer/domain/OrganizerRepositoryTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organizer/domain/OrganizerRepositoryTest.java
@@ -1,0 +1,66 @@
+package feedzupzup.backend.organizer.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import feedzupzup.backend.admin.domain.Admin;
+import feedzupzup.backend.admin.domain.AdminRepository;
+import feedzupzup.backend.admin.domain.fixture.AdminFixture;
+import feedzupzup.backend.config.RepositoryHelper;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OrganizerRepositoryTest extends RepositoryHelper {
+
+    @Autowired
+    private OrganizerRepository organizerRepository;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Test
+    @DisplayName("관리자 ID로 조직과 함께 페치된 오거나이저 목록을 조회한다")
+    void findAllFetchedByAdminId_success() {
+        // given
+        Admin admin = AdminFixture.create();
+        adminRepository.save(admin);
+
+        Organization organization1 = OrganizationFixture.createAllBlackBox();
+        Organization organization2 = OrganizationFixture.createAllBlackBox();
+        organizationRepository.save(organization1);
+        organizationRepository.save(organization2);
+
+        Organizer organizer1 = new Organizer(organization1, admin, OrganizerRole.OWNER);
+        Organizer organizer2 = new Organizer(organization2, admin, OrganizerRole.OWNER);
+        organizerRepository.save(organizer1);
+        organizerRepository.save(organizer2);
+
+        // when
+        List<Organizer> organizers = organizerRepository.findAllFetchedByAdminId(admin.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(organizers).hasSize(2),
+                () -> assertThat(organizers.get(0).getOrganization()).isNotNull(),
+                () -> assertThat(organizers.get(1).getOrganization()).isNotNull()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 관리자 ID로 조회하면 빈 목록을 반환한다")
+    void findAllFetchedByAdminId_notFound() {
+        // when
+        List<Organizer> organizers = organizerRepository.findAllFetchedByAdminId(999L);
+
+        // then
+        assertThat(organizers).isEmpty();
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#676 

## 🚀 작업 내용
- 회원 탈퇴 API 구현

## 💬 리뷰 중점사항

1. 명시적 삭제
cascade, orphanRemoval를 통해 삭제 기대하는 것보다 코드로 표현하는 것이 더 명시적이라고 판단해서, 코드로 모두 삭제했습니다.

2. service 참조.
각 도메인 별 삭제 로직이 변경가능성이 있기 때문에, repository가 아닌 service를 직접 참조했습니다.

3. 결합도 증가, 이벤트 기반 삭제 고려 또한, OCP 
도메인 삭제시, 해당 도메인과 관련된 서비스를 모두 참조해야해서 결합도 증가.
또한, 삭제하고자 하는 도메인과 관련되는 새로운 도메인이 생긴다면, 삭제 로직에 추가해야함.

그래서 이벤트 기반 로직 생각했으나, 복잡성 올라가서 일단 놔둠

위 3가지 의견 남겨주세요.