### PR TITLE
[BE] feat: 관리자의 단체 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/category/application/OrganizationCategoryService.java
+++ b/backend/src/main/java/feedzupzup/backend/category/application/OrganizationCategoryService.java
@@ -21,6 +21,11 @@ public class OrganizationCategoryService {
     }
 
     @Transactional
+    public void deleteByOrganizationId(final Long organizationId) {
+        organizationCategoryRepository.deleteByOrganizationId(organizationId);
+    }
+
+    @Transactional
     public void saveAll(final Set<OrganizationCategory> organizationCategories) {
         organizationCategoryRepository.saveAll(organizationCategories);
     }

--- a/backend/src/main/java/feedzupzup/backend/category/domain/OrganizationCategoryRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/category/domain/OrganizationCategoryRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface OrganizationCategoryRepository extends JpaRepository<OrganizationCategory, Long> {
 
     void deleteAllByOrganizationIdIn(Collection<Long> organizationIds);
+    
+    void deleteByOrganizationId(Long organizationId);
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
@@ -108,4 +108,9 @@ public class AdminFeedbackService {
     public void deleteAllByOrganizationIds(final List<Long> organizationIds) {
         feedBackRepository.deleteAllByOrganizationIdIn(organizationIds);
     }
+
+    @Transactional
+    public void deleteByOrganizationId(final Long organizationId) {
+        feedBackRepository.deleteAllByOrganizationId(organizationId);
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/FeedbackRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/FeedbackRepository.java
@@ -92,4 +92,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     FeedbackAmount findFeedbackStatisticsByAdminId(Long adminId);
 
     void deleteAllByOrganizationIdIn(List<Long> organizationIds);
+    
+    void deleteAllByOrganizationId(Long organizationId);
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/api/AdminOrganizationApi.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/api/AdminOrganizationApi.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -69,5 +70,16 @@ public interface AdminOrganizationApi {
     @GetMapping("/admin/organizations")
     SuccessResponse<List<AdminInquireOrganizationResponse>> getOrganizations(
             @Parameter(hidden = true) @AdminAuthenticationPrincipal final AdminSession adminSession
+    );
+
+    @Operation(summary = "단체 삭제", description = "단체를 삭제할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공", useReturnTypeSchema = true)
+    })
+    @SecurityRequirement(name = "SessionAuth")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/admin/organizations/{organizationUuid}")
+    SuccessResponse<Void> deleteOrganization(
+            @Parameter(hidden = true) @LoginOrganizer final LoginOrganizerInfo loginOrganizerInfo
     );
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -19,6 +19,7 @@ import feedzupzup.backend.organizer.domain.OrganizerRepository;
 import feedzupzup.backend.organizer.domain.OrganizerRole;
 import feedzupzup.backend.qr.service.QRService;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -110,8 +111,11 @@ public class AdminOrganizationService {
 
     @Transactional
     public void deleteOrganization(final UUID organizationUuid) {
-        final Organization organization = organizationRepository.findByUuid(organizationUuid)
-                .orElseThrow(() -> new ResourceNotFoundException("해당 UUID를 가진 단체는 존재하지 않습니다."));
+        final Optional<Organization> organizationOpt = organizationRepository.findByUuid(organizationUuid);
+        if (organizationOpt.isEmpty()) {
+            return;
+        }
+        final Organization organization = organizationOpt.get();
         final Long organizationId = organization.getId();
 
         organizerRepository.deleteAllByOrganization_Id(organizationId);

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -107,4 +107,17 @@ public class AdminOrganizationService {
         qrService.deleteAllByOrganizationIds(organizationIds);
         organizationRepository.deleteAllById(organizationIds);
     }
+
+    @Transactional
+    public void deleteOrganization(final UUID organizationUuid) {
+        final Organization organization = organizationRepository.findByUuid(organizationUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 UUID를 가진 단체는 존재하지 않습니다."));
+        final Long organizationId = organization.getId();
+
+        organizerRepository.deleteAllByOrganization_Id(organizationId);
+        organizationCategoryService.deleteByOrganizationId(organizationId);
+        adminFeedbackService.deleteByOrganizationId(organizationId);
+        qrService.deleteByOrganizationId(organizationId);
+        organizationRepository.delete(organization);
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/organization/controller/AdminOrganizationController.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/controller/AdminOrganizationController.java
@@ -2,7 +2,6 @@ package feedzupzup.backend.organization.controller;
 
 import feedzupzup.backend.admin.dto.AdminSession;
 import feedzupzup.backend.auth.presentation.annotation.AdminAuthenticationPrincipal;
-import feedzupzup.backend.auth.presentation.annotation.LoginOrganizer;
 import feedzupzup.backend.global.response.SuccessResponse;
 import feedzupzup.backend.organization.api.AdminOrganizationApi;
 import feedzupzup.backend.organization.application.AdminOrganizationService;
@@ -12,7 +11,6 @@ import feedzupzup.backend.organization.dto.response.AdminCreateOrganizationRespo
 import feedzupzup.backend.organization.dto.response.AdminInquireOrganizationResponse;
 import feedzupzup.backend.organization.dto.response.AdminUpdateOrganizationResponse;
 import feedzupzup.backend.organizer.dto.LoginOrganizerInfo;
-import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -56,5 +54,13 @@ public class AdminOrganizationController implements AdminOrganizationApi {
         final List<AdminInquireOrganizationResponse> response =
                 adminOrganizationService.getOrganizationsInfo(adminSession.adminId());
         return SuccessResponse.success(HttpStatus.OK, response);
+    }
+
+    @Override
+    public SuccessResponse<Void> deleteOrganization(
+            final LoginOrganizerInfo loginOrganizerInfo
+    ) {
+        adminOrganizationService.deleteOrganization(loginOrganizerInfo.organizationUuid());
+        return SuccessResponse.success(HttpStatus.NO_CONTENT);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/organizer/domain/OrganizerRepository.java
@@ -11,12 +11,12 @@ public interface OrganizerRepository extends JpaRepository<Organizer, Long> {
     @Query("SELECT o FROM Organizer o JOIN FETCH o.admin WHERE o.organization.id = :organizationId")
     List<Organizer> findByOrganizationId(@Param("organizationId") Long organizationId);
 
-    boolean existsOrganizerByAdmin_IdAndOrganization_Id(Long adminId, Long organizationId);
-
     boolean existsOrganizerByAdmin_IdAndOrganization_Uuid(Long adminId, UUID organizationUuid);
 
     void deleteAllByAdmin_Id(Long adminId);
 
     @Query("SELECT o FROM Organizer o JOIN FETCH o.organization WHERE o.admin.id = :adminId")
     List<Organizer> findAllFetchedByAdminId(Long adminId);
+
+    void deleteAllByOrganization_Id(Long organizationId);
 }

--- a/backend/src/main/java/feedzupzup/backend/qr/repository/QRRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/qr/repository/QRRepository.java
@@ -12,4 +12,6 @@ public interface QRRepository extends JpaRepository<QR, Long> {
     boolean existsByOrganizationId(Long id);
 
     void deleteAllByOrganizationIdIn(List<Long> organizationIds);
+    
+    void deleteByOrganizationId(Long organizationId);
 }

--- a/backend/src/main/java/feedzupzup/backend/qr/service/QRService.java
+++ b/backend/src/main/java/feedzupzup/backend/qr/service/QRService.java
@@ -92,4 +92,9 @@ public class QRService {
     public void deleteAllByOrganizationIds(final List<Long> organizationIds) {
         qrRepository.deleteAllByOrganizationIdIn(organizationIds);
     }
+
+    @Transactional
+    public void deleteByOrganizationId(final Long organizationId) {
+        qrRepository.deleteByOrganizationId(organizationId);
+    }
 }

--- a/backend/src/test/java/feedzupzup/backend/organization/application/AdminOrganizationServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/application/AdminOrganizationServiceTest.java
@@ -6,8 +6,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import feedzupzup.backend.admin.domain.Admin;
 import feedzupzup.backend.admin.domain.AdminRepository;
 import feedzupzup.backend.admin.domain.fixture.AdminFixture;
-import feedzupzup.backend.auth.exception.AuthException.ForbiddenException;
+import feedzupzup.backend.category.domain.Category;
+import feedzupzup.backend.category.domain.OrganizationCategory;
+import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
+import feedzupzup.backend.category.fixture.OrganizationCategoryFixture;
 import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.feedback.domain.FeedbackRepository;
+import feedzupzup.backend.feedback.fixture.FeedbackFixture;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
@@ -19,13 +25,6 @@ import feedzupzup.backend.organization.fixture.OrganizationFixture;
 import feedzupzup.backend.organizer.domain.Organizer;
 import feedzupzup.backend.organizer.domain.OrganizerRepository;
 import feedzupzup.backend.organizer.domain.OrganizerRole;
-import feedzupzup.backend.category.domain.Category;
-import feedzupzup.backend.category.domain.OrganizationCategory;
-import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
-import feedzupzup.backend.category.fixture.OrganizationCategoryFixture;
-import feedzupzup.backend.feedback.domain.Feedback;
-import feedzupzup.backend.feedback.domain.FeedbackRepository;
-import feedzupzup.backend.feedback.fixture.FeedbackFixture;
 import feedzupzup.backend.qr.domain.QR;
 import feedzupzup.backend.qr.repository.QRRepository;
 import java.util.Set;
@@ -156,7 +155,8 @@ class AdminOrganizationServiceTest extends ServiceIntegrationHelper {
         organizerRepository.save(new Organizer(organization, admin, OrganizerRole.OWNER));
 
         // 연관 데이터 생성
-        final OrganizationCategory category = OrganizationCategoryFixture.createOrganizationCategory(organization, Category.SUGGESTION);
+        final OrganizationCategory category = OrganizationCategoryFixture.createOrganizationCategory(organization,
+                Category.SUGGESTION);
         organizationCategoryRepository.save(category);
 
         final Feedback feedback = FeedbackFixture.createFeedbackWithContent(organization, "테스트 피드백", category);
@@ -176,18 +176,6 @@ class AdminOrganizationServiceTest extends ServiceIntegrationHelper {
         assertThat(organizationCategoryRepository.findById(category.getId())).isEmpty();
         assertThat(feedbackRepository.findById(feedback.getId())).isEmpty();
         assertThat(qrRepository.findById(qr.getId())).isEmpty();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 조직을 삭제하려 할 때 예외가 발생해야 한다")
-    void delete_nonexistent_organization_should_throw_exception() {
-        // given
-        final UUID nonexistentUuid = UUID.randomUUID();
-
-        // when & then
-        assertThatThrownBy(() -> adminOrganizationService.deleteOrganization(nonexistentUuid))
-                .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessageContaining("해당 UUID를 가진 단체는 존재하지 않습니다");
     }
 
     private Admin createAndSaveAdmin() {

--- a/backend/src/test/java/feedzupzup/backend/organization/application/AdminOrganizationServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/organization/application/AdminOrganizationServiceTest.java
@@ -9,10 +9,25 @@ import feedzupzup.backend.admin.domain.fixture.AdminFixture;
 import feedzupzup.backend.auth.exception.AuthException.ForbiddenException;
 import feedzupzup.backend.config.ServiceIntegrationHelper;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.organization.dto.request.CreateOrganizationRequest;
 import feedzupzup.backend.organization.dto.request.UpdateOrganizationRequest;
 import feedzupzup.backend.organization.dto.response.AdminCreateOrganizationResponse;
 import feedzupzup.backend.organization.dto.response.AdminUpdateOrganizationResponse;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import feedzupzup.backend.organizer.domain.Organizer;
+import feedzupzup.backend.organizer.domain.OrganizerRepository;
+import feedzupzup.backend.organizer.domain.OrganizerRole;
+import feedzupzup.backend.category.domain.Category;
+import feedzupzup.backend.category.domain.OrganizationCategory;
+import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
+import feedzupzup.backend.category.fixture.OrganizationCategoryFixture;
+import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.feedback.domain.FeedbackRepository;
+import feedzupzup.backend.feedback.fixture.FeedbackFixture;
+import feedzupzup.backend.qr.domain.QR;
+import feedzupzup.backend.qr.repository.QRRepository;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +41,21 @@ class AdminOrganizationServiceTest extends ServiceIntegrationHelper {
 
     @Autowired
     private AdminRepository adminRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizerRepository organizerRepository;
+
+    @Autowired
+    private OrganizationCategoryRepository organizationCategoryRepository;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private QRRepository qrRepository;
 
     @Test
     @DisplayName("정상적인 admin이 조직을 생성하려고 할 때, 생성할 수 있어야 한다.")
@@ -99,6 +129,65 @@ class AdminOrganizationServiceTest extends ServiceIntegrationHelper {
         // then
         assertThat(updateResponse.updateName()).isEqualTo("우테코코코");
         assertThat(updateResponse.updateCategories()).containsExactlyInAnyOrder("기타", "칭찬", "정보공유");
+    }
+
+    @Test
+    @DisplayName("조직을 성공적으로 삭제할 수 있어야 한다")
+    void delete_organization_success() {
+        // given
+        final Admin admin = createAndSaveAdmin();
+        final Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+        organizerRepository.save(new Organizer(organization, admin, OrganizerRole.OWNER));
+
+        // when
+        adminOrganizationService.deleteOrganization(organization.getUuid());
+
+        // then
+        assertThat(organizationRepository.findByUuid(organization.getUuid())).isEmpty();
+        assertThat(organizerRepository.findByOrganizationId(organization.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조직과 연관된 모든 데이터가 함께 삭제되어야 한다")
+    void delete_organization_with_all_related_data() {
+        // given
+        final Admin admin = createAndSaveAdmin();
+        final Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+        organizerRepository.save(new Organizer(organization, admin, OrganizerRole.OWNER));
+
+        // 연관 데이터 생성
+        final OrganizationCategory category = OrganizationCategoryFixture.createOrganizationCategory(organization, Category.SUGGESTION);
+        organizationCategoryRepository.save(category);
+
+        final Feedback feedback = FeedbackFixture.createFeedbackWithContent(organization, "테스트 피드백", category);
+        feedbackRepository.save(feedback);
+
+        final QR qr = new QR("test-image-url", organization);
+        qrRepository.save(qr);
+
+        final Long organizationId = organization.getId();
+
+        // when
+        adminOrganizationService.deleteOrganization(organization.getUuid());
+
+        // then - 조직과 연관된 모든 데이터가 삭제되어야 함
+        assertThat(organizationRepository.findByUuid(organization.getUuid())).isEmpty();
+        assertThat(organizerRepository.findByOrganizationId(organizationId)).isEmpty();
+        assertThat(organizationCategoryRepository.findById(category.getId())).isEmpty();
+        assertThat(feedbackRepository.findById(feedback.getId())).isEmpty();
+        assertThat(qrRepository.findById(qr.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 조직을 삭제하려 할 때 예외가 발생해야 한다")
+    void delete_nonexistent_organization_should_throw_exception() {
+        // given
+        final UUID nonexistentUuid = UUID.randomUUID();
+
+        // when & then
+        assertThatThrownBy(() -> adminOrganizationService.deleteOrganization(nonexistentUuid))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("해당 UUID를 가진 단체는 존재하지 않습니다");
     }
 
     private Admin createAndSaveAdmin() {


### PR DESCRIPTION
## 😉 연관 이슈

#679 

## 🚀 작업 내용

- 관리자의 단체 삭제 API 추가
- 추가된 기능에 대한 테스트 추가

## 💬 리뷰 중점사항

단체 삭제 시 존재하지 않는 단체면 예외를 던집니다. 사실 예외를 던지지 않아도 되는 상황이라고 생각하는데요.
연관된 데이터들을 uuid가 아닌 id로 삭제하기 위해 조회를 먼저 하다보니 예외를 던지게 되었습니다.

결론적으로 모든 데이터를 UUID로 직접 삭제 vs ID 조회 후 id로 모두 삭제 중 후자를 선택했습니다. 성능을 고려해서요.
의견 부탁드립니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 관리자용 단체 삭제 기능 추가: /admin/organizations/{organizationUuid} DELETE 지원(성공 시 204).
  * 단체 삭제 시 연관 데이터(주최자, 카테고리, 피드백, QR)를 함께 삭제해 데이터 일관성 유지.
  * 권한/인증 적용: 소유자만 삭제 가능, 권한 없을 경우 403, 비인증 시 401 응답.

* 테스트
  * 서비스 및 E2E 테스트 추가: 정상 삭제, 권한 없음(403), 비인증(401) 시나리오 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->