### PR TITLE
[BE] fix: flyway 초기화 에러 수정

### DIFF
--- a/backend/src/main/resources/db/migration/V23__remove_unique_constraint_notification_token_admin_id.sql
+++ b/backend/src/main/resources/db/migration/V23__remove_unique_constraint_notification_token_admin_id.sql
@@ -1,1 +1,6 @@
+ALTER TABLE notification_token DROP FOREIGN KEY fk_notification_token_admin;
+
 ALTER TABLE notification_token DROP INDEX uk_notification_token_admin_id;
+
+ALTER TABLE notification_token ADD CONSTRAINT fk_notification_token_admin
+    FOREIGN KEY (admin_id) REFERENCES admin(id) ON DELETE CASCADE;


### PR DESCRIPTION
## 😉 연관 이슈
#713 

## 🚀 작업 내용
초기에 Admin 과 NotificationToken의 연관관계가 1:1 이었어서, V16 스키마가 아래와 같았습니다.
```sql
CREATE TABLE notification_token (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,
    registration_token VARCHAR(500) NOT NULL,
    admin_id BIGINT,
    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    modified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
    
    CONSTRAINT uk_notification_token_admin_id UNIQUE (admin_id),
    CONSTRAINT fk_notification_token_admin FOREIGN KEY (admin_id) REFERENCES admin(id) ON DELETE CASCADE
);
```
추후에 1:N으로 관계가 변경되면서 notification_token의 adminId의 유니크 제약을 지우는 V23를 추가했었는데요. 근데 앞에 V16에서 외래키가 걸려있다보니, 유니크 제약 조건을 지우는게 실패했나봅니다!

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 없음
- 버그 수정
  - 관리자 계정 삭제 시 연관된 알림 토큰이 자동으로 정리되어 데이터 불일치와 잔여 데이터로 인한 오류 가능성을 감소시켰습니다.
- Chores
  - 데이터베이스 제약 조건을 조정하여 삭제 시 연쇄 정리를 보장, 시스템 안정성과 데이터 일관성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->