### PR TITLE
[FE] refactor: 최소한의 변경만 일으키기(피드백 작성 + 관리자 설정 페이지)

### DIFF
--- a/frontend/src/domains/admin/Settings/Settings.tsx
+++ b/frontend/src/domains/admin/Settings/Settings.tsx
@@ -16,7 +16,7 @@ export default function Settings() {
   const [modalState, setModalState] = useState<ModalState>({ type: null });
   const { isToggleEnabled, updateNotificationSetting, isLoading, fcmStatus } =
     useNotificationSettingsPage();
-  const { adminAuth } = useAdminAuth();
+  const { adminAuth, isLoading: isAdminAuthLoading } = useAdminAuth();
   const { handleLogout } = useLogout();
 
   const closeModal = () => {
@@ -30,8 +30,9 @@ export default function Settings() {
   return (
     <div css={settingsContainer}>
       <ProfileBox
-        name={adminAuth?.adminName || '관리자'}
-        id={adminAuth?.loginId || 'admin'}
+        isLoading={isAdminAuthLoading}
+        name={adminAuth?.adminName || ''}
+        id={adminAuth?.loginId || ''}
       />
 
       <SettingListBox

--- a/frontend/src/domains/admin/Settings/components/ProfileBox/ProfileBox.style.ts
+++ b/frontend/src/domains/admin/Settings/components/ProfileBox/ProfileBox.style.ts
@@ -5,6 +5,7 @@ export const profileBox = (theme: Theme) => css`
   flex-direction: column;
   gap: 8px;
   width: 100%;
+  min-height: 80px;
   padding: 20px 24px;
   background-color: ${theme.colors.purple[100]}22;
   border-radius: 10px;
@@ -14,10 +15,12 @@ export const adminName = (theme: Theme) => css`
   ${theme.typography.pretendard.captionBold}
 
   color: ${theme.colors.purple[200]};
+  transition: opacity 0.3s ease;
 `;
 
 export const adminId = (theme: Theme) => css`
   ${theme.typography.pretendard.captionSmall}
 
   color: ${theme.colors.gray[600]};
+  transition: opacity 0.3s ease;
 `;

--- a/frontend/src/domains/admin/Settings/components/ProfileBox/ProfileBox.tsx
+++ b/frontend/src/domains/admin/Settings/components/ProfileBox/ProfileBox.tsx
@@ -4,14 +4,15 @@ import { useAppTheme } from '@/hooks/useAppTheme';
 interface ProfileBoxProps {
   name: string;
   id: string;
+  isLoading: boolean;
 }
 
-export default function ProfileBox({ name, id }: ProfileBoxProps) {
+export default function ProfileBox({ name, id, isLoading }: ProfileBoxProps) {
   const theme = useAppTheme();
   return (
     <div css={profileBox(theme)}>
-      <p css={adminName(theme)}>{name}</p>
-      <p css={adminId(theme)}>{id}</p>
+      <p css={[adminName(theme), { opacity: isLoading ? 0 : 1 }]}>{name}</p>
+      <p css={[adminId(theme), { opacity: isLoading ? 0 : 1 }]}>{id}</p>
     </div>
   );
 }

--- a/frontend/src/domains/admin/Settings/hooks/useAdminAuth.ts
+++ b/frontend/src/domains/admin/Settings/hooks/useAdminAuth.ts
@@ -7,10 +7,12 @@ import { useEffect, useState } from 'react';
 export default function useAdminAuth() {
   const [adminAuth, setAdminAuth] = useState<AdminAuthData | null>(null);
   const { handleApiError } = useApiErrorHandler();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     (async () => {
       try {
+        setIsLoading(true);
         await getAdminAuth({
           onSuccess: (response: AdminAuthResponse) =>
             setAdminAuth(response.data),
@@ -18,9 +20,11 @@ export default function useAdminAuth() {
       } catch (error) {
         handleApiError(error as ApiError);
         setAdminAuth(null);
+      } finally {
+        setIsLoading(false);
       }
     })();
   }, []);
 
-  return { adminAuth };
+  return { adminAuth, isLoading };
 }

--- a/frontend/src/domains/admin/Settings/hooks/useNotificationSettingsPage.ts
+++ b/frontend/src/domains/admin/Settings/hooks/useNotificationSettingsPage.ts
@@ -33,7 +33,9 @@ export const useNotificationSettingsPage = () => {
       return;
     }
 
-    updateMutation.mutate({ enabled });
+    setTimeout(() => {
+      updateMutation.mutate({ enabled });
+    }, 250);
   };
 
   return {

--- a/frontend/src/domains/hooks/useOrganizationName.ts
+++ b/frontend/src/domains/hooks/useOrganizationName.ts
@@ -15,7 +15,7 @@ export default function useOrganizationName({
   const { showErrorModal } = useErrorModalContext();
   const { handleApiError } = useApiErrorHandler();
 
-  const { data, error } = useQuery({
+  const { data, error, isLoading } = useQuery({
     queryKey: [...QUERY_KEYS.organizationData, organizationId],
     queryFn: async () => {
       const response = await getOrganizationName({ organizationId });
@@ -35,5 +35,6 @@ export default function useOrganizationName({
     groupName: data?.organizationName || '피드줍줍',
     totalCheeringCount: data?.totalCheeringCount || 0,
     categories: data?.categories || [],
+    isLoading,
   };
 }

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
@@ -61,5 +61,7 @@ export const buttonContainer = css`
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 10px;
+  min-height: 140px;
   margin-top: 8%;
+  transition: opacity 0.4s ease-in-out;
 `;

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
@@ -24,6 +24,7 @@ export const title = (theme: Theme) => css`
   ${theme.typography.pretendard.h1}
 
   margin-top: 8%;
+  color: ${theme.colors.black[100]};
 `;
 
 export const place = (theme: Theme) => css`
@@ -31,6 +32,7 @@ export const place = (theme: Theme) => css`
 
   font-size: 32px;
   color: ${theme.colors.purple[100]};
+  transition: opacity 0.3s ease;
 `;
 
 export const questionTitle = (theme: Theme) => css`

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
@@ -53,7 +53,7 @@ export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
           <p css={questionTitle(theme)}>카테고리 선택</p>
           <p css={question(theme)}>건의하고 싶은 카테고리를 선택해주세요</p>
         </div>
-        <div css={buttonContainer}>
+        <div css={[buttonContainer, { opacity: isLoading ? 0 : 1 }]}>
           {categoryIconPairs.map((category) => (
             <CategoryButton
               key={category.category}

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.tsx
@@ -28,7 +28,7 @@ export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
   const { goPath } = useNavigation();
   const { organizationId } = useOrganizationId();
 
-  const { groupName, categories } = useOrganizationName({
+  const { groupName, categories, isLoading } = useOrganizationName({
     organizationId,
   });
 
@@ -44,8 +44,10 @@ export default function OnBoarding({ onCategoryClick }: OnBoardingProps) {
     <section css={container}>
       <div>
         <p css={title(theme)}>
-          <span css={place(theme)}>{groupName}</span>에<br /> 오신 것을
-          환영합니다
+          <span css={[place(theme), { opacity: isLoading ? 0 : 1 }]}>
+            {groupName} <span css={title(theme)}>에</span>
+          </span>
+          <br /> 오신 것을 환영합니다
         </p>
         <div css={questionContainer(theme)}>
           <p css={questionTitle(theme)}>카테고리 선택</p>

--- a/frontend/src/domains/user/home/components/FeedbackInput/FeedbackForm.tsx
+++ b/frontend/src/domains/user/home/components/FeedbackInput/FeedbackForm.tsx
@@ -58,13 +58,11 @@ export default function FeedbackForm({
             customCSS={usernameInput(theme)}
             maxLength={10}
             minLength={1}
-            disabled={isLocked}
           />
         </div>
 
         <Button
           onClick={onRandomChange}
-          disabled={isLocked}
           css={randomButton(theme)}
           type='button'
         >

--- a/frontend/src/domains/user/home/hooks/useUsername.ts
+++ b/frontend/src/domains/user/home/hooks/useUsername.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { generateRandomUsername } from '../utils/feedbackUtils';
 
 export interface UseUsernameReturn {
@@ -9,39 +9,34 @@ export interface UseUsernameReturn {
   handleUsernameFocus: () => void;
 }
 
-export function useUsername(isLocked: boolean): UseUsernameReturn {
+export function useUsername(): UseUsernameReturn {
   const [username, setUsername] = useState(() => generateRandomUsername());
 
   const [isUsernameEdited, setIsUsernameEdited] = useState(false);
 
-  const handleRandomChange = useCallback(() => {
-    if (isLocked) return;
-
+  const handleRandomChange = () => {
     const newUsername = generateRandomUsername();
     setUsername(newUsername as typeof username);
 
     setIsUsernameEdited(false);
-  }, [isLocked]);
+  };
 
-  const handleUsernameChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setUsername(e.target.value as typeof username);
-      setIsUsernameEdited(true);
-    },
-    []
-  );
+  const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUsername(e.target.value as typeof username);
+    setIsUsernameEdited(true);
+  };
 
-  const handleUsernameFocus = useCallback(() => {
+  const handleUsernameFocus = () => {
     if (!isUsernameEdited) {
       setUsername('' as typeof username);
       setIsUsernameEdited(true);
     }
-  }, [isUsernameEdited]);
+  };
 
-  const resetUsername = useCallback(() => {
+  const resetUsername = () => {
     setUsername(generateRandomUsername());
     setIsUsernameEdited(false);
-  }, []);
+  };
 
   return {
     username,


### PR DESCRIPTION
## 😉 연관 이슈

#705 

## 🚀 작업 내용
- 특정 상호작용이 있었을때 관련없는 다른 업데이트가 일어나는건  (피드백 제출 첫페이지, 두번째 페이지, 설정페이지) 모두 발생하기 않았고
- layout shift는 (피드백 제출 첫페이지)에서 일어나길래 수정했고, 다른 페이지에서는 마찬가지로 모든 상호작용에서 나타나지 않습니다.
- frame Drop은 설정페이지에서 토글을 눌렀을때 일어났고, 수정했습니다.

- 위의 업무가 너무 적다고 생각해서 비밀글 토글 눌렀을때 닉네임이나 건의 내용이 수정되지 않던 로직을 수정되도록 수정했고
- 온보딩 첫페이지에서 피드줍줍이라는 기본값에서 띱하고 단체 명이 바뀌는 UX문제를 해결하고자 페이드인방식으로 단체명과 카테고리 박스가 나타나도록 수정했습니다. 설정페이지의 닉네임도 '관리자'라는 기본 닉네임에서 API에서 받아온 값으로 바뀌는 문제를 해결하기 위해 같은 방식으로 값이 나타나도록 수정했습니다.

상세한 변경 내용은 아래에 적어놓았습니다.
https://www.notion.so/26ff333ebf828036a761f5cacd82f62f?source=copy_link

## 💬 리뷰 중점사항
