### PR TITLE
[BE] feat: 존재하지 않는 조직으로 피드백 조회시 예외처리

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
@@ -16,6 +16,7 @@ import feedzupzup.backend.feedback.dto.response.FeedbackStatisticResponse;
 import feedzupzup.backend.feedback.dto.response.UpdateFeedbackCommentResponse;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.global.log.BusinessActionLog;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class AdminFeedbackService {
     private final FeedbackRepository feedBackRepository;
     private final FeedbackSortStrategyFactory feedbackSortStrategyFactory;
     private final FeedbackLikeService feedbackLikeService;
+    private final OrganizationRepository organizationRepository;
 
     @Transactional
     @BusinessActionLog
@@ -50,6 +52,9 @@ public class AdminFeedbackService {
             final ProcessStatus status,
             final FeedbackSortBy sortBy
     ) {
+        if (!organizationRepository.existsOrganizationByUuid(organizationUuid)) {
+            throw new ResourceNotFoundException("해당 ID(id = " + organizationUuid + ")인 단체를 찾을 수 없습니다.");
+        }
         final Pageable pageable = Pageable.ofSize(size + 1);
 
         FeedbackSortStrategy feedbackSortStrategy = feedbackSortStrategyFactory.find(sortBy);

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/AdminFeedbackServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/AdminFeedbackServiceTest.java
@@ -24,6 +24,7 @@ import feedzupzup.backend.feedback.dto.response.AdminFeedbackListResponse;
 import feedzupzup.backend.feedback.dto.response.FeedbackStatisticResponse;
 import feedzupzup.backend.feedback.dto.response.UpdateFeedbackCommentResponse;
 import feedzupzup.backend.feedback.fixture.FeedbackFixture;
+import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.organization.fixture.OrganizationFixture;
@@ -195,22 +196,17 @@ class AdminFeedbackServiceTest extends ServiceIntegrationHelper {
         }
 
         @Test
-        @DisplayName("빈 결과에 대해 적절히 처리한다")
+        @DisplayName("존재하지 않는 단체를 조회하면 예외를 발생시킨다.")
         void getAllFeedbacks_empty_result() {
             // given
             final UUID organizationUuid = UUID.randomUUID();
             final int size = 10;
 
             // when
-            final AdminFeedbackListResponse response = adminFeedbackService.getFeedbackPage(
-                    organizationUuid, size, null, null, LATEST);
-
-            // then
-            assertAll(
-                    () -> assertThat(response.feedbacks()).isEmpty(),
-                    () -> assertThat(response.hasNext()).isFalse(),
-                    () -> assertThat(response.nextCursorId()).isNull()
-            );
+            assertThatThrownBy(() -> {
+                adminFeedbackService.getFeedbackPage(
+                        organizationUuid, size, null, null, LATEST);
+            }).isInstanceOf(ResourceNotFoundException.class);
         }
     }
 


### PR DESCRIPTION
## 🚀 작업 내용
존재하지 않는 조직으로 피드백 조회시 예외처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 없음
- 버그 수정
  - 존재하지 않는 조직의 피드백 조회 시 빈 결과 대신 ‘리소스를 찾을 수 없음’ 오류를 반환하여 잘못된 조직 ID에 대한 응답을 명확화.
- 테스트
  - 예외 발생 시나리오를 검증하도록 테스트 케이스 업데이트.
- 작업(Chores)
  - 백엔드 서브모듈 커밋 갱신(기능 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->