### PR TITLE
[BE] feat: 좋아요 기록 조회 API 구현 및 쿠키 오류 해결

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
@@ -4,6 +4,7 @@ import feedzupzup.backend.feedback.domain.vo.FeedbackSortBy;
 import feedzupzup.backend.feedback.domain.vo.ProcessStatus;
 import feedzupzup.backend.feedback.dto.request.CreateFeedbackRequest;
 import feedzupzup.backend.feedback.dto.response.CreateFeedbackResponse;
+import feedzupzup.backend.feedback.dto.response.LikeHistoryResponse;
 import feedzupzup.backend.feedback.dto.response.LikeResponse;
 import feedzupzup.backend.feedback.dto.response.MyFeedbackListResponse;
 import feedzupzup.backend.feedback.dto.response.StatisticResponse;
@@ -110,5 +111,17 @@ public interface UserFeedbackApi {
             @Parameter(description = "단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000") @PathVariable("organizationUuid") final UUID organizationUuid,
             @Parameter(description = "정렬 기준", example = "LATEST, OLDEST, LIKES") @RequestParam(defaultValue = "LATEST") final FeedbackSortBy sortBy,
             @Parameter(description = "내가 쓴 피드백 ID 목록") @RequestParam final List<Long> feedbackIds
+    );
+
+    @Operation(summary = "좋아요 목록 조회", description = "본인이 누른 좋아요 목록들을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "401", ref = "#/components/responses/NotFound")
+    })
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/organizations/{organizationUuid}/feedbacks/my-likes")
+    SuccessResponse<LikeHistoryResponse> getMyLikeHistories(
+            @Parameter(description = "단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000") @PathVariable("organizationUuid") final UUID organizationUuid,
+            @Parameter(hidden = true) @CookieValue(name = CookieUtilization.VISITOR_KEY, required = false) UUID visitorId
     );
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
@@ -116,7 +116,6 @@ public interface UserFeedbackApi {
     @Operation(summary = "좋아요 목록 조회", description = "본인이 누른 좋아요 목록들을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "401", ref = "#/components/responses/NotFound")
     })
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/feedbacks/my-likes")

--- a/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
@@ -119,9 +119,8 @@ public interface UserFeedbackApi {
             @ApiResponse(responseCode = "401", ref = "#/components/responses/NotFound")
     })
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/organizations/{organizationUuid}/feedbacks/my-likes")
+    @GetMapping("/feedbacks/my-likes")
     SuccessResponse<LikeHistoryResponse> getMyLikeHistories(
-            @Parameter(description = "단체 UUID", example = "123e4567-e89b-12d3-a456-426614174000") @PathVariable("organizationUuid") final UUID organizationUuid,
             @Parameter(hidden = true) @CookieValue(name = CookieUtilization.VISITOR_KEY, required = false) UUID visitorId
     );
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/api/UserFeedbackApi.java
@@ -121,6 +121,7 @@ public interface UserFeedbackApi {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/feedbacks/my-likes")
     SuccessResponse<LikeHistoryResponse> getMyLikeHistories(
+            final HttpServletResponse response,
             @Parameter(hidden = true) @CookieValue(name = CookieUtilization.VISITOR_KEY, required = false) UUID visitorId
     );
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackLikeService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackLikeService.java
@@ -1,8 +1,12 @@
 package feedzupzup.backend.feedback.application;
 
+import feedzupzup.backend.auth.exception.AuthException;
+import feedzupzup.backend.auth.exception.AuthException.UnauthorizedException;
 import feedzupzup.backend.feedback.domain.FeedbackRepository;
 import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.feedback.domain.LikeFeedbacks;
 import feedzupzup.backend.feedback.domain.UserLikeFeedbacksRepository;
+import feedzupzup.backend.feedback.dto.response.LikeHistoryResponse;
 import feedzupzup.backend.feedback.dto.response.LikeResponse;
 import feedzupzup.backend.feedback.exception.FeedbackException.DuplicateLikeException;
 import feedzupzup.backend.feedback.exception.FeedbackException.InvalidLikeException;
@@ -56,5 +60,15 @@ public class FeedbackLikeService {
         return feedBackRepository.findById(feedbackId)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "feedbackId " + feedbackId + "는 존재하지 않습니다."));
+    }
+
+    public LikeHistoryResponse getLikeHistories(final UUID organizationId, UUID visitorId) {
+        if (visitorId == null) {
+            throw new ResourceNotFoundException("해당 visitorId " + visitorId + "는 존재하지 않습니다");
+        }
+        final LikeFeedbacks likeFeedbacks = userLikeFeedbacksRepository.getUserLikeFeedbacksFrom(
+                organizationId);
+
+        return LikeHistoryResponse.from(likeFeedbacks);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackLikeService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackLikeService.java
@@ -62,12 +62,12 @@ public class FeedbackLikeService {
                         "feedbackId " + feedbackId + "는 존재하지 않습니다."));
     }
 
-    public LikeHistoryResponse getLikeHistories(final UUID organizationId, UUID visitorId) {
+    public LikeHistoryResponse getLikeHistories(final UUID visitorId) {
         if (visitorId == null) {
             throw new ResourceNotFoundException("해당 visitorId " + visitorId + "는 존재하지 않습니다");
         }
         final LikeFeedbacks likeFeedbacks = userLikeFeedbacksRepository.getUserLikeFeedbacksFrom(
-                organizationId);
+                visitorId);
 
         return LikeHistoryResponse.from(likeFeedbacks);
     }

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackLikeService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackLikeService.java
@@ -1,7 +1,5 @@
 package feedzupzup.backend.feedback.application;
 
-import feedzupzup.backend.auth.exception.AuthException;
-import feedzupzup.backend.auth.exception.AuthException.UnauthorizedException;
 import feedzupzup.backend.feedback.domain.FeedbackRepository;
 import feedzupzup.backend.feedback.domain.Feedback;
 import feedzupzup.backend.feedback.domain.LikeFeedbacks;
@@ -62,13 +60,9 @@ public class FeedbackLikeService {
                         "feedbackId " + feedbackId + "는 존재하지 않습니다."));
     }
 
-    public LikeHistoryResponse getLikeHistories(final UUID visitorId) {
-        if (visitorId == null) {
-            throw new ResourceNotFoundException("해당 visitorId " + visitorId + "는 존재하지 않습니다");
-        }
+    public LikeHistoryResponse findLikeHistories(final UUID visitorId) {
         final LikeFeedbacks likeFeedbacks = userLikeFeedbacksRepository.getUserLikeFeedbacksFrom(
                 visitorId);
-
         return LikeHistoryResponse.from(likeFeedbacks);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
@@ -105,11 +105,9 @@ public class UserFeedbackController implements UserFeedbackApi {
 
     @Override
     public SuccessResponse<LikeHistoryResponse> getMyLikeHistories(
-            final UUID organizationUuid,
             final UUID visitorId
     ) {
-        final LikeHistoryResponse response = feedbackLikeService.getLikeHistories(
-                organizationUuid, visitorId);
+        final LikeHistoryResponse response = feedbackLikeService.getLikeHistories(visitorId);
         return SuccessResponse.success(HttpStatus.OK, response);
     }
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
@@ -9,13 +9,13 @@ import feedzupzup.backend.feedback.application.UserFeedbackService;
 import feedzupzup.backend.feedback.domain.vo.ProcessStatus;
 import feedzupzup.backend.feedback.dto.request.CreateFeedbackRequest;
 import feedzupzup.backend.feedback.dto.response.CreateFeedbackResponse;
+import feedzupzup.backend.feedback.dto.response.LikeHistoryResponse;
 import feedzupzup.backend.feedback.dto.response.LikeResponse;
 import feedzupzup.backend.feedback.dto.response.MyFeedbackListResponse;
 import feedzupzup.backend.feedback.dto.response.StatisticResponse;
 import feedzupzup.backend.feedback.dto.response.UserFeedbackListResponse;
 import feedzupzup.backend.global.response.SuccessResponse;
 import feedzupzup.backend.global.util.CookieUtilization;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.UUID;
@@ -100,6 +100,16 @@ public class UserFeedbackController implements UserFeedbackApi {
         final StatisticResponse response = feedbackStatisticService.calculateStatistic(
                 organizationUuid
         );
+        return SuccessResponse.success(HttpStatus.OK, response);
+    }
+
+    @Override
+    public SuccessResponse<LikeHistoryResponse> getMyLikeHistories(
+            final UUID organizationUuid,
+            final UUID visitorId
+    ) {
+        final LikeHistoryResponse response = feedbackLikeService.getLikeHistories(
+                organizationUuid, visitorId);
         return SuccessResponse.success(HttpStatus.OK, response);
     }
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/controller/UserFeedbackController.java
@@ -105,9 +105,20 @@ public class UserFeedbackController implements UserFeedbackApi {
 
     @Override
     public SuccessResponse<LikeHistoryResponse> getMyLikeHistories(
+            final HttpServletResponse httpServletResponse,
             final UUID visitorId
     ) {
-        final LikeHistoryResponse response = feedbackLikeService.getLikeHistories(visitorId);
+        if (visitorId == null) {
+            UUID cookieId = UUID.randomUUID();
+            final ResponseCookie cookie = CookieUtilization.createCookie(
+                    CookieUtilization.VISITOR_KEY,
+                    cookieId
+            );
+            httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+            final LikeHistoryResponse response = feedbackLikeService.findLikeHistories(cookieId);
+            return SuccessResponse.success(HttpStatus.OK, response);
+        }
+        final LikeHistoryResponse response = feedbackLikeService.findLikeHistories(visitorId);
         return SuccessResponse.success(HttpStatus.OK, response);
     }
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/UserLikeFeedbacksRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/UserLikeFeedbacksRepository.java
@@ -2,6 +2,7 @@ package feedzupzup.backend.feedback.domain;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Repository;
@@ -39,6 +40,7 @@ public class UserLikeFeedbacksRepository {
     }
 
     public LikeFeedbacks getUserLikeFeedbacksFrom(final UUID visitorId) {
-        return userLikeFeedbacks.get(visitorId);
+        return Optional.ofNullable(userLikeFeedbacks.get(visitorId))
+                .orElse(new LikeFeedbacks());
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/UserLikeFeedbacksRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/UserLikeFeedbacksRepository.java
@@ -37,4 +37,8 @@ public class UserLikeFeedbacksRepository {
     public Map<UUID, LikeFeedbacks> getUserLikeFeedbacks() {
         return Collections.unmodifiableMap(userLikeFeedbacks);
     }
+
+    public LikeFeedbacks getUserLikeFeedbacksFrom(final UUID visitorId) {
+        return userLikeFeedbacks.get(visitorId);
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/dto/response/LikeHistoryResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/dto/response/LikeHistoryResponse.java
@@ -1,0 +1,22 @@
+package feedzupzup.backend.feedback.dto.response;
+
+import feedzupzup.backend.feedback.domain.LikeFeedbacks;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Set;
+
+@Schema(description = "좋아요 기록 조회")
+public record LikeHistoryResponse(
+
+        @Schema(description = "좋아요 횟수", example = "1")
+        List<Long> likeHistories
+)   {
+        public static LikeHistoryResponse from(final LikeFeedbacks likeFeedbacks) {
+            final Set<Long> likes = likeFeedbacks.getLikeFeedbacks();
+
+            final List<Long> sortedLikeHistories = likes.stream()
+                    .sorted()
+                    .toList();
+            return new LikeHistoryResponse(sortedLikeHistories);
+        }
+}

--- a/backend/src/main/java/feedzupzup/backend/feedback/dto/response/LikeHistoryResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/dto/response/LikeHistoryResponse.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public record LikeHistoryResponse(
 
         @Schema(description = "좋아요 횟수", example = "1")
-        List<Long> likeHistories
+        List<Long> feedbackIds
 )   {
         public static LikeHistoryResponse from(final LikeFeedbacks likeFeedbacks) {
             final Set<Long> likes = likeFeedbacks.getLikeFeedbacks();

--- a/backend/src/main/java/feedzupzup/backend/feedback/dto/response/LikeHistoryResponse.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/dto/response/LikeHistoryResponse.java
@@ -8,7 +8,7 @@ import java.util.Set;
 @Schema(description = "좋아요 기록 조회")
 public record LikeHistoryResponse(
 
-        @Schema(description = "좋아요 횟수", example = "1")
+        @Schema(description = "좋아요 누른 피드백 ID 목록(오름차순)", example = "[1, 3, 5]")
         List<Long> feedbackIds
 )   {
         public static LikeHistoryResponse from(final LikeFeedbacks likeFeedbacks) {

--- a/backend/src/main/java/feedzupzup/backend/global/util/CookieUtilization.java
+++ b/backend/src/main/java/feedzupzup/backend/global/util/CookieUtilization.java
@@ -18,6 +18,7 @@ public class CookieUtilization {
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
+                .path("/")
                 .build();
         log.info("쿠키 생성 완료 : {" + "key = " + key + ", value = " + value + "}");
         return responseCookie;


### PR DESCRIPTION
## 😉 연관 이슈
#749 

## 🚀 작업 내용
- 좋아요 기록 조회 API 구현
- 쿠키가 게속해서 발급되는 버그 수정

## 💬 리뷰 중점사항
Controller 분기처리는 나중에 Interceptor로 분리하려고 합니다. 이 부분 제외하고 봐주시면 될 것 같아요.
버그 사항 수정이라, 빠르게 prod 머지까지 하려고 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 내 좋아요 이력 조회 API 추가: GET /feedbacks/my-likes가 사용자가 좋아요한 피드백 ID 목록(feedbackIds)을 반환합니다. 방문자 쿠키가 없으면 새 쿠키를 발급합니다.
- Chores
  - 방문자 쿠키의 경로를 루트(/)로 설정하여 전역 식별 일관성 개선.
- Tests
  - 서비스 및 E2E 테스트 추가: 무쿠키, 단일/다건 좋아요 이력 조회 시나리오 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->