### PR TITLE
[BE] fix: Organization 삭제 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -119,8 +119,8 @@ public class AdminOrganizationService {
         final Long organizationId = organization.getId();
 
         organizerRepository.deleteAllByOrganization_Id(organizationId);
-        organizationCategoryService.deleteByOrganizationId(organizationId);
         adminFeedbackService.deleteByOrganizationId(organizationId);
+        organizationCategoryService.deleteByOrganizationId(organizationId);
         qrService.deleteByOrganizationId(organizationId);
         organizationRepository.delete(organization);
     }

--- a/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/domain/OrganizationCategories.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrganizationCategories {
 
-    @OneToMany(mappedBy = "organization", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "organization", cascade = CascadeType.PERSIST)
     private final Set<OrganizationCategory> organizationCategories = new HashSet<>();
 
     public void addAll(final Set<String> categories, final Organization organization) {

--- a/backend/src/main/resources/db/migration/V26__modify_organization_category_id_nullable.sql
+++ b/backend/src/main/resources/db/migration/V26__modify_organization_category_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feedback MODIFY COLUMN organization_category_id BIGINT NULL;

--- a/backend/src/main/resources/db/migration/V27__modify_organization_id_nullable_in_organization_category.sql
+++ b/backend/src/main/resources/db/migration/V27__modify_organization_id_nullable_in_organization_category.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organization_category
+MODIFY COLUMN organization_id bigint NULL;


### PR DESCRIPTION
## 😉 연관 이슈
#751 

## 🚀 작업 내용

- Organization 삭제시 AdminOrganizationService에서 Feedback보다 OrganizationCategory가 먼저 삭제되고 있었고, Feedback이 OrganizationCategory의 외래키를 갖고 있는 상황에서  OrganizationCategory를 먼저 삭제하려 했기 때문에 TransientObjectException 발생 했습니다.

-> Feedback, OrganizationCategory 삭제 순서 수정

- JPA는 소프트 삭제할 때 연관관계로 인해 존재하는 외래키를 null로 수정하려고 시도합니다. 예를 들어 Feedback 소프트 삭제 시 OrganizationCategoryId를 null로 수정하게 됩니다. 하지만 현재 Feedback의 OrganizationCategoryId에 null 허용이 안되어 있기 때문에 소프트 삭제시 SQLException이 발생 했습니다.

-> V26에 Feedback의 OrganizationCategoryId  null 허용 스키마 추가

- OrganizationCategory의 경우 Organization 연관관계 매핑 옵션 중 orphanRemoval = true가 되어 있기 때문에, OrganizationCategory소프트 삭제시 JPA가 Organization_id를 null로 수정하지 않습니다. 그 이유는 부모 엔티티(Organization)가 삭제될 시 자식 엔티티(OrganizationCategory)가 하드 삭제 되므로 부모 엔티티의 외래키를 null로 만들 필요가 없기 때문입니다. 그리고 저희가 모든 엔티티는 소프트 삭제를 하는것으로 협의를 하였기에 결론적으로 orphanRemoval = true 설정을 제거하기로 했습니다

-> OrganizationCategory의 orphanRemoval = true 설정 제거

### orphanRemoval 단점

orphanRemoval = true 설정 시 성능 이슈가 발생하는 이유

JPA의 orphanRemoval 동작 방식

#### 컬렉션 로딩 필수:
// 만약 Organization에 이런 설정이 있다면:
@OneToMany(mappedBy = "organization", orphanRemoval = true)
private Set<Feedback> feedbacks = new HashSet<>();

// Organization 삭제 시:
organizationRepository.delete(organization); // 이 시점에서!
#### JPA가 해야 할 일:
- Organization과 연관된 모든 Feedback을 메모리로 로드
- 각 Feedback을 컬렉션에서 제거 (orphan 상태로 만듦)
- orphan이 된 Feedback들을 하나씩 삭제
#### 성능 문제 발생:
// JPA 내부적으로 이런 일이 발생:

// 1) 모든 Feedback 조회 (메모리 로드)
SELECT * FROM feedback WHERE organization_id = ?; // 10만 건이라면?

// 2) 각각 개별 삭제
DELETE FROM feedback WHERE id = 1;
DELETE FROM feedback WHERE id = 2;
DELETE FROM feedback WHERE id = 3;
// ... 10만 번 반복!

수동 삭제 방식의 장점

// 현재 방식:
adminFeedbackService.deleteAllByOrganizationIds(organizationIds);

// 실제 실행되는 SQL:
UPDATE feedback SET deleted_at = CURRENT_TIMESTAMP
WHERE organization_id IN (?, ?, ?); // 단 1번의 쿼리!

결론:

- orphanRemoval: N+1 문제 + 메모리 과부하
- 수동 삭제: 단일 벌크 쿼리로 효율적 처리

따라서 대량 데이터가 있는 환경에서는 현재의 수동 삭제 방식이 훨씬 효율적



## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 조직 삭제 시 연관 피드백·카테고리·QR가 누락 없이 함께 정리(소프트 삭제)되도록 처리 순서 안정화로 데이터 무결성 개선.

* 작업(데이터베이스)
  * 피드백의 organization_category_id를 NULL 허용으로 변경해 삭제/정리 과정의 유연한 상태 전이 지원.

* 테스트
  * 조직 삭제 시 연관 데이터(주최자, 카테고리, 피드백, QR)까지 정리되는지 검증하는 통합 및 E2E 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->