### PR TITLE
[FE] fix: 메인화면 카테고리 크기 줄이기

### DIFF
--- a/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
@@ -61,7 +61,7 @@ export const buttonContainer = css`
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 10px;
-  min-height: 140px;
+
   margin-top: 8%;
   transition: opacity 0.4s ease-in-out;
 `;

--- a/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
+++ b/frontend/src/domains/user/OnBoarding/OnBoarding.styles.ts
@@ -61,7 +61,6 @@ export const buttonContainer = css`
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 10px;
-
   margin-top: 8%;
   transition: opacity 0.4s ease-in-out;
 `;


### PR DESCRIPTION
## 😉 연관 이슈
#765 

## 🚀 작업 내용
온보딩 페이지 카테고리 크기 줄였습니다!

개선전
<img width="535" height="602" alt="image" src="https://github.com/user-attachments/assets/b8615a68-2db4-4d3d-a95e-28b777fc9507" />

개선후
<img width="535" height="602" alt="image" src="https://github.com/user-attachments/assets/e51028d2-6bf3-4cc8-ab27-9b1d9346dded" />
