### PR TITLE
[FE] feat: admin에서 하트를 누를수 없게 보이게 만들기

### DIFF
--- a/frontend/src/domains/admin/adminDashboard/components/AdminFeedbackBox/AdminFeedbackBox.tsx
+++ b/frontend/src/domains/admin/adminDashboard/components/AdminFeedbackBox/AdminFeedbackBox.tsx
@@ -65,6 +65,7 @@ export default memo(function AdminFeedbackBox({
       {type === 'CONFIRMED' && comment && <FeedbackAnswer answer={comment} />}
       <FeedbackBoxFooter
         type={type}
+        isAdmin={true}
         likeCount={likeCount}
         postedAt={postedAt}
         feedbackId={feedbackId}

--- a/frontend/src/domains/components/FeedbackBoxFooter/FeedbackBoxFooter.tsx
+++ b/frontend/src/domains/components/FeedbackBoxFooter/FeedbackBoxFooter.tsx
@@ -19,6 +19,7 @@ interface FeedbackBoxFooterProps {
   isSecret?: boolean;
   feedbackId: number;
   type: FeedbackStatusType;
+  isAdmin?: boolean;
 }
 
 export default function FeedbackBoxFooter({
@@ -28,6 +29,7 @@ export default function FeedbackBoxFooter({
   isSecret,
   feedbackId,
   type,
+  isAdmin = false,
 }: FeedbackBoxFooterProps) {
   const theme = useAppTheme();
 
@@ -47,6 +49,7 @@ export default function FeedbackBoxFooter({
             like={isLiked}
             feedbackId={feedbackId}
             likeCount={likeCount}
+            isAdmin={isAdmin}
           />
         )}
       </div>

--- a/frontend/src/domains/components/LikeButton/LikeButton.style.ts
+++ b/frontend/src/domains/components/LikeButton/LikeButton.style.ts
@@ -14,3 +14,16 @@ export const iconWrapper = (theme: Theme, isLiked: boolean) => css`
   align-items: center;
   color: ${isLiked ? theme.colors.red[50] : theme.colors.gray[300]};
 `;
+
+export const adminLikeText = (theme: Theme) => css`
+  color: ${theme.colors.gray[600]};
+  ${theme.typography.pretendard.captionSmall}
+`;
+
+export const likeCountText = (theme: Theme) => css`
+  ${theme.typography.pretendard.captionSmall}
+
+  font-weight: 800;
+  letter-spacing: 1px;
+  color: ${theme.colors.gray[600]};
+`;

--- a/frontend/src/domains/components/LikeButton/LikeButton.tsx
+++ b/frontend/src/domains/components/LikeButton/LikeButton.tsx
@@ -5,25 +5,39 @@ import FillHeartIcon from '../../../components/icons/FillHeartIcon';
 import {
   likeButton,
   iconWrapper,
+  adminLikeText,
+  likeCountText,
 } from '@/domains/components/LikeButton/LikeButton.style';
-import { theme } from '@/theme';
+
+import { useAppTheme } from '@/hooks/useAppTheme';
 
 interface LikeButtonProps {
   like: boolean | undefined;
   feedbackId: number | undefined;
   likeCount: number;
+  isAdmin?: boolean;
 }
 
 export default function LikeButton({
   like,
   feedbackId,
   likeCount,
+  isAdmin,
 }: LikeButtonProps) {
+  const theme = useAppTheme();
   const { handleLikeButton, isLiked, tempLikeCount } = useLikeButtonManager({
     like,
     feedbackId,
     likeCount,
   });
+
+  if (isAdmin) {
+    return (
+      <span css={adminLikeText(theme)}>
+        <strong css={likeCountText(theme)}>{tempLikeCount}</strong>개의 좋아요
+      </span>
+    );
+  }
 
   return (
     <Button onClick={handleLikeButton} css={likeButton}>


### PR DESCRIPTION
## 😉 연관 이슈
#768 

## 🚀 작업 내용
관리자 화면일때 좋아요를 누를수 없게 보이는 UX로 바뀌었습니다.
<img width="1150" height="724" alt="image" src="https://github.com/user-attachments/assets/66907df7-b112-4888-a26a-f2cf540ff0b5" />



## 💬 리뷰 중점사항
