### PR TITLE
[BE] feat: 피드백 작성 시 욕설 필터링 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,9 @@ dependencies {
 
     //firebase
     implementation 'com.google.firebase:firebase-admin:9.5.0'
+
+    //profanity filter
+    implementation 'io.github.vaneproject:vane-badwordfiltering:1.0.0'
 }
 
 tasks.register('copySecret', Copy) {

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/vo/Content.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/vo/Content.java
@@ -2,6 +2,7 @@ package feedzupzup.backend.feedback.domain.vo;
 
 import feedzupzup.backend.feedback.exception.FeedbackException;
 import feedzupzup.backend.global.response.ErrorCode;
+import com.vane.badwordfiltering.BadWordFiltering;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -14,13 +15,15 @@ import lombok.NoArgsConstructor;
 public class Content {
 
     private static final int MAX_LENGTH = 500;
+    private static final String[] SUBSTITUTION_WORDS = {"멍멍", "야옹", "음메"};
+    private static final BadWordFiltering FILTER = new BadWordFiltering();
 
     @Column(name = "content")
     private String value;
 
     public Content(final String value) {
         validateLength(value);
-        this.value = value;
+        this.value = filterProfanity(value);
     }
 
     private void validateLength(final String value) {
@@ -29,5 +32,18 @@ public class Content {
                     ErrorCode.INVALID_CONTENT_LENGTH,
                     "content의 length은 " + MAX_LENGTH + "를 초과할 수 없습니다.");
         }
+    }
+
+    private String filterProfanity(final String value) {
+        if (!FILTER.check(value)) {
+            return value;
+        }
+
+        String result = FILTER.change(value);
+        int index = 0;
+        while (result.contains("*")) {
+            result = result.replaceFirst("\\*+", SUBSTITUTION_WORDS[index++ % SUBSTITUTION_WORDS.length]);
+        }
+        return result;
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/feedback/domain/vo/ContentTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/domain/vo/ContentTest.java
@@ -1,0 +1,49 @@
+package feedzupzup.backend.feedback.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ContentTest {
+
+    @Test
+    @DisplayName("정상적인 내용으로 Content를 생성한다")
+    void createContent_withValidContent() {
+        // given
+        final String validContent = "좋은 피드백입니다";
+
+        // when
+        final Content content = new Content(validContent);
+
+        // then
+        assertThat(content.getValue()).isEqualTo(validContent);
+    }
+
+    @Test
+    @DisplayName("욕설이 포함된 내용은 동물 소리로 치환된다")
+    void createContent_withProfanity_replacesWithAnimalSounds() {
+        // given
+        final String profanityContent = "시발 이거 진짜 좋네요";
+
+        // when
+        final Content content = new Content(profanityContent);
+
+        // then
+        assertThat(content.getValue()).isNotEqualTo(profanityContent);
+        assertThat(content.getValue()).containsAnyOf("멍멍", "야옹", "음메");
+    }
+
+    @Test
+    @DisplayName("사용자가 입력한 별표는 그대로 유지된다")
+    void createContent_withAsterisks_keepsOriginal() {
+        // given
+        final String contentWithAsterisks = "이거 정말 좋아요 **";
+
+        // when
+        final Content content = new Content(contentWithAsterisks);
+
+        // then
+        assertThat(content.getValue()).isEqualTo(contentWithAsterisks);
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#811 

## 🚀 작업 내용

욕설은 `멍멍, 야옹, 음메` 로 치환 돼서 저장이 됩니다 !

일부 욕설은 라이브러리 한계로 치환이 안되는점 참고 부탁드립니다~


## 💬 리뷰 중점사항
