### PR TITLE
[FE] fix: 좋아요 버튼 버그 수정(백엔드 API연동)

### DIFF
--- a/frontend/src/apis/userFeedback.api.ts
+++ b/frontend/src/apis/userFeedback.api.ts
@@ -88,3 +88,17 @@ export async function getMyFeedbacks({
 
   return response as GetMyFeedbacksResponse;
 }
+
+export interface GetMyLikedFeedbacksResponse {
+  data: {
+    feedbackIds: number[];
+  };
+}
+
+export async function getMyLikedFeedbacks() {
+  const response = await apiClient.get<GetMyLikedFeedbacksResponse>(
+    '/feedbacks/my-likes'
+  );
+
+  return response as GetMyLikedFeedbacksResponse;
+}

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -16,4 +16,5 @@ export const QUERY_KEYS = {
   ) => ['myFeedbacks', organizationId, feedbackIds, selectedSort] as const,
   infiniteList: (key: string, url: string, size: number) =>
     ['infinity', key, url, size] as const,
+  myLikeFeedbackIds: ['myLikeFeedbackIds'] as const,
 };

--- a/frontend/src/domains/components/FeedbackBoxFooter/FeedbackBoxFooter.tsx
+++ b/frontend/src/domains/components/FeedbackBoxFooter/FeedbackBoxFooter.tsx
@@ -46,7 +46,7 @@ export default function FeedbackBoxFooter({
         )}
         {!isSecret && (
           <LikeButton
-            like={isLiked}
+            like={isLiked ?? false}
             feedbackId={feedbackId}
             likeCount={likeCount}
             isAdmin={isAdmin}

--- a/frontend/src/domains/components/LikeButton/LikeButton.tsx
+++ b/frontend/src/domains/components/LikeButton/LikeButton.tsx
@@ -12,7 +12,7 @@ import {
 import { useAppTheme } from '@/hooks/useAppTheme';
 
 interface LikeButtonProps {
-  like: boolean | undefined;
+  like: boolean;
   feedbackId: number | undefined;
   likeCount: number;
   isAdmin?: boolean;

--- a/frontend/src/domains/user/userDashboard/components/UserFeedbackList/UserFeedbackList.tsx
+++ b/frontend/src/domains/user/userDashboard/components/UserFeedbackList/UserFeedbackList.tsx
@@ -1,20 +1,20 @@
 import useGetFeedback from '@/domains/admin/adminDashboard/hooks/useGetFeedback';
 import FeedbackBoxList from '@/domains/components/FeedbackBoxList/FeedbackBoxList';
+import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
 import UserFeedbackBox from '@/domains/user/userDashboard/components/UserFeedbackBox/UserFeedbackBox';
 import useHighLighted from '@/domains/user/userDashboard/hooks/useHighLighted';
-import {
-  FeedbackResponse,
-  FeedbackType,
-  FeedbackFilterType,
-  SortType,
-} from '@/types/feedback.types';
+import useMyLikedFeedback from '@/domains/user/userDashboard/hooks/useMyLikedFeedback';
 import { createFeedbacksUrl } from '@/domains/utils/createFeedbacksUrl';
 import useCursorInfiniteScroll from '@/hooks/useCursorInfiniteScroll';
-import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
-import FeedbackStatusMessage from '../FeedbackStatusMessage/FeedbackStatusMessage';
-import { useMyFeedbackData } from '../../hooks/useMyFeedbackData';
+import {
+  FeedbackFilterType,
+  FeedbackResponse,
+  FeedbackType,
+  SortType,
+} from '@/types/feedback.types';
 import { memo, useCallback, useMemo } from 'react';
-import { getLocalStorage } from '@/utils/localStorage';
+import { useMyFeedbackData } from '../../hooks/useMyFeedbackData';
+import FeedbackStatusMessage from '../FeedbackStatusMessage/FeedbackStatusMessage';
 
 interface UserFeedbackListProps {
   selectedFilter: '' | FeedbackFilterType;
@@ -26,7 +26,7 @@ export default memo(function UserFeedbackList({
   selectedSort,
 }: UserFeedbackListProps) {
   const { organizationId } = useOrganizationId();
-  const likedFeedbackIds = getLocalStorage<number[]>('feedbackIds') || [];
+  const { myLikeFeedbackIds } = useMyLikedFeedback();
 
   const apiUrl = useMemo(
     () =>
@@ -71,9 +71,12 @@ export default memo(function UserFeedbackList({
     [selectedFilter, myFeedbacks, feedbacks]
   );
 
-  const getFeedbackIsLike = useCallback((feedbackId: number) => {
-    return likedFeedbackIds?.includes(feedbackId) || false;
-  }, []);
+  const getFeedbackIsLike = useCallback(
+    (feedbackId: number) => {
+      return myLikeFeedbackIds?.includes(feedbackId) || false;
+    },
+    [myLikeFeedbackIds]
+  );
 
   return (
     <>

--- a/frontend/src/domains/user/userDashboard/hooks/useMyLikedFeedback.ts
+++ b/frontend/src/domains/user/userDashboard/hooks/useMyLikedFeedback.ts
@@ -1,0 +1,14 @@
+import { getMyLikedFeedbacks } from '@/apis/userFeedback.api';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useMyLikedFeedback() {
+  const { data: myLikeFeedbackIds, refetch: refetchMyLikeFeedbackIds } =
+    useQuery({
+      queryKey: QUERY_KEYS.myLikeFeedbackIds,
+      queryFn: getMyLikedFeedbacks,
+      select: (res) => res.data.feedbackIds,
+    });
+
+  return { myLikeFeedbackIds: myLikeFeedbackIds, refetchMyLikeFeedbackIds };
+}


### PR DESCRIPTION
## 😉 연관 이슈
 #748

## 🚀 작업 내용

- localStoage에서 관리하던 좋아요 값을 "**🌟쿠기🌟**"기반으로 변경
- 서버로부터 좋아요 표시한 피드백 가져오는 api 로직 생성

## 💬 리뷰 중점사항

- 좋아요 버그가 완전히 해결된건지는 백엔드 코드 수정돼봐야 알 수 잇을 것 같아용~
  - 정상으로 값을 가져오는 api 기준으론 제대로 동작합니다!
  - 백엔드 수정 후에도 버그가 안고쳐지면 이슈 따로 파둘께요~
- 다음 작업이 이거랑 연결돼있다고 들어서 PR 올립니다

['기-승-결'의 트러블슈팅...](https://wonderful-taker-be7.notion.site/285f333ebf82801eaa2cd75ea0281fef?source=copy_link)

