### PR TITLE
[BE] fix: 캐시 버그 수정

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/service/cache/FeedbackCacheRemover.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/service/cache/FeedbackCacheRemover.java
@@ -1,0 +1,43 @@
+package feedzupzup.backend.feedback.domain.service.cache;
+
+import static feedzupzup.backend.global.domain.CacheType.LATEST_FEEDBACK;
+import static feedzupzup.backend.global.domain.CacheType.LIKES_FEEDBACK;
+import static feedzupzup.backend.global.domain.CacheType.OLDEST_FEEDBACK;
+
+import feedzupzup.backend.feedback.dto.response.FeedbackItem;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeedbackCacheRemover {
+
+    private final CacheHelper cacheHelper;
+
+    public void removeAllFeedbackCachesInfContains(
+            final FeedbackItem feedbackItem,
+            final UUID organizationUuid
+    ) {
+        removeCacheIfContains(feedbackItem, organizationUuid, LIKES_FEEDBACK.getCacheName());
+        removeCacheIfContains(feedbackItem, organizationUuid, LATEST_FEEDBACK.getCacheName());
+        removeCacheIfContains(feedbackItem, organizationUuid, OLDEST_FEEDBACK.getCacheName());
+    }
+
+    private void removeCacheIfContains(
+            final FeedbackItem feedbackItem,
+            final UUID organizationUuid,
+            final String cacheName
+    ) {
+        cacheHelper.<FeedbackItem>getCacheValueList(organizationUuid, cacheName)
+                .filter(items -> containsFeedback(items, feedbackItem))
+                .ifPresent(items -> cacheHelper.removeCache(organizationUuid, cacheName));
+    }
+
+    private boolean containsFeedback(final List<FeedbackItem> items, final FeedbackItem feedbackItem) {
+        return items.stream()
+                .anyMatch(item -> item.feedbackId().equals(feedbackItem.feedbackId()));
+    }
+
+}

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/service/cache/LikesCacheHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/service/cache/LikesCacheHandler.java
@@ -14,9 +14,15 @@ import org.springframework.stereotype.Component;
 public class LikesCacheHandler implements FeedbackCacheHandler {
 
     private final CacheHelper cacheHelper;
+    private final FeedbackCacheRemover feedbackCacheRemover;
 
     @Override
     public void handle(final FeedbackItem savedFeedbackItem, final UUID organizationUuid) {
+        feedbackCacheRemover.removeAllFeedbackCachesInfContains(savedFeedbackItem, organizationUuid);
+        handleLikesCache(savedFeedbackItem, organizationUuid);
+    }
+
+    private void handleLikesCache(final FeedbackItem savedFeedbackItem, final UUID organizationUuid) {
         final Optional<List<FeedbackItem>> findCachedFeedbacks = cacheHelper.getCacheValueList(
                 organizationUuid, LIKES_FEEDBACK.getCacheName());
         if (findCachedFeedbacks.isEmpty()) {

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/service/cache/OldestCacheHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/service/cache/OldestCacheHandler.java
@@ -1,10 +1,6 @@
 package feedzupzup.backend.feedback.domain.service.cache;
 
-import static feedzupzup.backend.global.domain.CacheType.*;
-
 import feedzupzup.backend.feedback.dto.response.FeedbackItem;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,23 +9,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OldestCacheHandler implements FeedbackCacheHandler {
 
-    private final CacheHelper cacheHelper;
+    private final FeedbackCacheRemover feedbackCacheRemover;
 
     @Override
     public void handle(final FeedbackItem savedFeedbackItem, final UUID organizationUuid) {
-        final Optional<List<FeedbackItem>> findCachedFeedbacks = cacheHelper.getCacheValueList(
-                organizationUuid, OLDEST_FEEDBACK.getCacheName());
-        if (findCachedFeedbacks.isEmpty()) {
-            return;
-        }
-
-        final List<FeedbackItem> feedbackItems = findCachedFeedbacks.get();
-
-        final boolean alreadyCached = feedbackItems.stream()
-                .anyMatch(feedbackItem -> feedbackItem.feedbackId().equals(savedFeedbackItem.feedbackId()));
-
-        if (alreadyCached) {
-            cacheHelper.removeCache(organizationUuid, OLDEST_FEEDBACK.getCacheName());
-        }
+        feedbackCacheRemover.removeAllFeedbackCachesInfContains(savedFeedbackItem, organizationUuid);
     }
 }


### PR DESCRIPTION
## 😉 연관 이슈
#816 

## 🚀 작업 내용
- 피드백 좋아요 증감시, 해당 피드백이 다른 캐시에 속해있다면 전부 삭제하도록 수정
- 피드백 상태 변경 시, 해당 피드백이 다른 캐시에 속해있다면 전부 삭제하도록 수정

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 좋아요/좋아요 취소 및 상태 변경 시 최신/오래된/인기 피드백 목록이 간헐적으로 갱신되지 않던 문제를 수정했습니다. 이제 관련 목록이 더 빠르고 일관되게 최신 상태로 반영됩니다.
* **Tests**
  * 교차 캐시 무효화 시나리오(좋아요 증가/감소, 상태 변경 등)를 추가하여 목록 갱신과 DB 조회 트리거를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->