### PR TITLE
[FE] fix: 관리자 답변 삐져나옴 문제

### DIFF
--- a/frontend/src/domains/components/FeedbackAnswer/FeedbackAnswer.styles.ts
+++ b/frontend/src/domains/components/FeedbackAnswer/FeedbackAnswer.styles.ts
@@ -9,6 +9,9 @@ export const container = (theme: Theme) => css`
   padding: 10px;
   background-color: #fbfffd;
   border-left: 2px solid ${theme.colors.green[200]};
+  white-space: pre-wrap;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 `;
 
 export const title = (theme: Theme) => css`


### PR DESCRIPTION
## 😉 연관 이슈
#833 

## 🚀 작업 내용
문제가 왜 발생했냐면 지금은 단어 단위로 줄바꿈이 진행되고 있었는데, dfasdfafsfdasd << 이렇게 영단어나 한글이 띄어쓰기 없이 입력된 경우는 줄바꿈을 못하더라구요!

그래서 아래 속성들을 사용해 만약 띄어쓰기가 없는 경우 width를 넘지 않고 줄바꿈이 되도록 수정했습니다!
```css
word-break: keep-all;
overflow-wrap: break-word;
```
<img width="564" height="258" alt="image" src="https://github.com/user-attachments/assets/307f9375-5ad9-4b6d-b6a1-ed3499f2b9de" />

