### PR TITLE
[BE] chore: DB Replication 라우팅 설정 추가 (Writer/Reader 분리)

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/global/config/datasource/DataSourceConfig.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/datasource/DataSourceConfig.java
@@ -1,0 +1,73 @@
+package feedzupzup.backend.global.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Slf4j
+@Configuration
+public class DataSourceConfig {
+
+    public enum DataSourceKey {
+        WRITER, READER;
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(
+            prefix = "spring.datasource.replication",
+            name = "enabled",
+            havingValue = "true"
+    )
+    public DataSource routingDataSource(
+            @Qualifier("writerDataSource") DataSource writer,
+            @Qualifier("readerDataSource") DataSource reader
+    ) {
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put(DataSourceKey.WRITER, writer);
+        targetDataSources.put(DataSourceKey.READER, reader);
+
+        ReplicationRoutingDataSource routing = new ReplicationRoutingDataSource();
+        routing.setDefaultTargetDataSource(writer);
+        routing.setTargetDataSources(targetDataSources);
+        routing.afterPropertiesSet();
+
+        return new LazyConnectionDataSourceProxy(routing);
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.writer")
+    @ConditionalOnProperty(
+            prefix = "spring.datasource.replication",
+            name = "enabled",
+            havingValue = "true"
+    )
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.reader")
+    @ConditionalOnProperty(
+            prefix = "spring.datasource.replication",
+            name = "enabled",
+            havingValue = "true"
+    )
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/config/datasource/DataSourceConfig.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/datasource/DataSourceConfig.java
@@ -4,7 +4,6 @@ import com.zaxxer.hikari.HikariDataSource;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -14,12 +13,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
-@Slf4j
 @Configuration
 public class DataSourceConfig {
 
     public enum DataSourceKey {
-        WRITER, READER;
+        WRITER, READER,
+        ;
     }
 
     @Bean
@@ -30,14 +29,14 @@ public class DataSourceConfig {
             havingValue = "true"
     )
     public DataSource routingDataSource(
-            @Qualifier("writerDataSource") DataSource writer,
-            @Qualifier("readerDataSource") DataSource reader
+            @Qualifier("writerDataSource") final DataSource writer,
+            @Qualifier("readerDataSource") final DataSource reader
     ) {
-        Map<Object, Object> targetDataSources = new HashMap<>();
+        final Map<Object, Object> targetDataSources = new HashMap<>();
         targetDataSources.put(DataSourceKey.WRITER, writer);
         targetDataSources.put(DataSourceKey.READER, reader);
 
-        ReplicationRoutingDataSource routing = new ReplicationRoutingDataSource();
+        final ReplicationRoutingDataSource routing = new ReplicationRoutingDataSource();
         routing.setDefaultTargetDataSource(writer);
         routing.setTargetDataSources(targetDataSources);
         routing.afterPropertiesSet();

--- a/backend/src/main/java/feedzupzup/backend/global/config/datasource/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/datasource/ReplicationRoutingDataSource.java
@@ -1,0 +1,19 @@
+package feedzupzup.backend.global.config.datasource;
+
+
+import feedzupzup.backend.global.config.datasource.DataSourceConfig.DataSourceKey;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (isTransactionReadOnly) {
+            return DataSourceKey.READER;
+        }
+        return DataSourceKey.WRITER;
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/config/datasource/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/datasource/ReplicationRoutingDataSource.java
@@ -9,7 +9,7 @@ public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
 
     @Override
     protected Object determineCurrentLookupKey() {
-        boolean isTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        final boolean isTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
 
         if (isTransactionReadOnly) {
             return DataSourceKey.READER;


### PR DESCRIPTION
## 😉 연관 이슈

#861 

## 🚀 작업 내용

서브모듈 변경 커밋: 

**DataSource 설정 분리**
- application-prod.yml 등 프로파일에서 spring.datasource.writer.* 및 spring.datasource.reader.* 설정으로 DB 엔드포인트를 분리하여 관리

**DataSourceConfig**
- spring.datasource.replication.enabled: true 설정 시 Writer/Reader 데이터소스를 구성하고, ReplicationRoutingDataSource를 Primary DataSource로 등록

**ReplicationRoutingDataSource**
- 트랜잭션의 readOnly 속성을 기준으로 연결 대상(Writer/Reader)을 동적으로 결정하는 라우팅 로직을 구현

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 읽기/쓰기 복제 데이터소스와 트랜잭션 기반 자동 라우팅이 도입되어 읽기 전용 작업은 읽기 복제본으로, 쓰기는 쓰기본으로 분산 처리됩니다.

* **성능 개선**
  * 읽기·쓰기 분리로 데이터베이스 부하 분산과 전체 응답 속도 향상이 기대됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->