### PR TITLE
[FE] fix: 피드백 제출 에러

### DIFF
--- a/frontend/src/domains/user/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/domains/user/FeedbackPage/FeedbackPage.tsx
@@ -84,15 +84,11 @@ export default function FeedbackPage({
     handleLockToggle();
   };
 
-  const handleModalClose = useCallback(
-    (isError: boolean) => {
-      closeModal();
-      if (!isError) {
-        goPath(`/${organizationId}/dashboard`);
-      }
-    },
-    [goPath]
-  );
+  const handleModalClose = useCallback(() => {
+    closeModal();
+
+    goPath(`/${organizationId}/dashboard`);
+  }, [goPath]);
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -106,7 +102,7 @@ export default function FeedbackPage({
 
       openModal(
         <TimeDelayModal
-          onClose={() => handleModalClose(submitStatus === 'error')}
+          onClose={() => handleModalClose()}
           loadingDuration={800}
           autoCloseDuration={1000}
         />

--- a/frontend/src/domains/user/home/hooks/useFeedbackForm.ts
+++ b/frontend/src/domains/user/home/hooks/useFeedbackForm.ts
@@ -29,7 +29,7 @@ export function useFeedbackForm(): UseFeedbackFormReturn {
     resetUsername,
   } = useUsername();
 
-  const canSubmit = feedback.trim().length > 0;
+  const canSubmit = feedback.trim().length > 0 && username.trim().length > 0;
 
   const resetForm = useCallback(() => {
     resetFeedback();


### PR DESCRIPTION
## 😉 연관 이슈
#883 

## 🚀 작업 내용
닉네임을 빈값 제출하고 다시 피드백 제출시 리다이렉션 안되는 에러 해결을 해결했는데여
무엇이 문제였냐!!
바로바로
에러가 발생해서 submitStatus가 error상태가 되어서, 페이지가 이동하지 않는 문제가 발생했슴다
에러가 발생하면  submitStatus가 error상태가 되고, 이후 피드백 작성 성공을 해서 submitStatus를 success로 바꾸는데 이때 이게 상태 변경인데, 그 전에 모달을 닫는 함수가 실행되면서 내비게이션이 되지 않더라구요~

그래서 `handleModalClose`함수에 isError로 에러인지 판별하는 로직을 제거했슴다
그리고 피드백 제출 닉네임이 없을 때, 제출못하도록 막았슴다


## 💬 리뷰 중점사항
