### PR TITLE
[FE] fix: 관리자 답변 글자 수 변경

### DIFF
--- a/frontend/src/components/TextareaCounter/TextareaCounter.styles.ts
+++ b/frontend/src/components/TextareaCounter/TextareaCounter.styles.ts
@@ -1,10 +1,9 @@
 import { Theme } from '@/theme';
 import { css } from '@emotion/react';
 
-export const textareaCounter = (theme: Theme) => css`
+export const textareaCounter = (theme: Theme, inset: string) => css`
   position: absolute;
-  right: 16px;
-  bottom: 8px;
+  inset: ${inset};
   color: ${theme.colors.gray[500]};
   ${theme.typography.pretendard.captionSmall}
 

--- a/frontend/src/components/TextareaCounter/TextareaCounter.tsx
+++ b/frontend/src/components/TextareaCounter/TextareaCounter.tsx
@@ -4,12 +4,25 @@ import { useAppTheme } from '@/hooks/useAppTheme';
 
 interface TextareaCounter {
   textLength: number;
+  top?: string;
+  left?: string;
+  right?: string;
+  bottom?: string;
 }
 
-export default function TextareaCounter({ textLength }: TextareaCounter) {
+export default function TextareaCounter({
+  textLength,
+  top,
+  left,
+  right,
+  bottom,
+}: TextareaCounter) {
   const theme = useAppTheme();
+  const inset = `${top ?? 'auto'} ${right ?? 'auto'} ${bottom ?? 'auto'} ${
+    left ?? 'auto'
+  }`;
   return (
-    <p css={textareaCounter(theme)}>
+    <p css={textareaCounter(theme, inset)}>
       {textLength} / {FEEDBACK_FORM_CONSTANTS.DEFAULTS.MAX_LENGTH}
     </p>
   );

--- a/frontend/src/domains/components/AnswerModal/AnswerModal.tsx
+++ b/frontend/src/domains/components/AnswerModal/AnswerModal.tsx
@@ -42,13 +42,17 @@ export default function AnswerModal({
         <div css={textareaContainer}>
           <TextArea
             minLength={1}
-            maxLength={200}
+            maxLength={500}
             value={answer}
             onChange={handleAnswerChange}
             placeholder='사용자에게 전달할 메시지를 작성해주세요.(선택사항)'
             customCSS={contentTextarea(theme)}
           />
-          <TextareaCounter textLength={answer.length} />
+          <TextareaCounter
+            textLength={answer.length}
+            right='16px'
+            bottom='-23px'
+          />
         </div>
         {answer.length === 0 ? (
           <p>답변 없이 완료 처리됩니다.</p>

--- a/frontend/src/domains/user/home/components/FeedbackInput/FeedbackForm.tsx
+++ b/frontend/src/domains/user/home/components/FeedbackInput/FeedbackForm.tsx
@@ -89,7 +89,11 @@ export default function FeedbackForm({
             maxLength={FEEDBACK_FORM_CONSTANTS.DEFAULTS.MAX_LENGTH}
             minLength={FEEDBACK_FORM_CONSTANTS.DEFAULTS.MIN_LENGTH}
           />
-          <TextareaCounter textLength={feedback.length} />
+          <TextareaCounter
+            textLength={feedback.length}
+            right='16px'
+            bottom='8px'
+          />
         </div>
       </div>
       <div css={formFooterContainer}>


### PR DESCRIPTION
## 😉 연관 이슈
#886

## 🚀 작업 내용
- 관리자 답변 글자 수 변경
- 글자 수 카운팅 UI 변경
<img width="725" height="411" alt="image" src="https://github.com/user-attachments/assets/225fb37f-cd67-492c-abe1-7554e7e3f5aa" />

- 피드백 작성 UI에서도 글자 수 카운트가 텍스트에 가리는 문제를 발견했는데요, 글자 수 카운트를 이동시킬만한 적절한 공간이 안보이더라구요 ㅠㅠ
그래서 우선은 수정해두진 않았는데 혹시 좋은 아이디어 있으면 추천 부탁합니당..
<img width="646" height="264" alt="image" src="https://github.com/user-attachments/assets/56a9b7a9-b33d-4a0c-bddd-a1a9e5f1f8cf" />


## 💬 리뷰 중점사항
