### PR TITLE
[BE] refactor: 어드민 id 글자 수 제한 5글자 이상 10글자 이하로 수정

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/admin/domain/vo/AdminName.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/domain/vo/AdminName.java
@@ -11,7 +11,6 @@ public record AdminName(
         String value
 ) {
 
-    private static final int MIN_LENGTH = 5;
     private static final int MAX_LENGTH = 20;
     private static final Pattern ALLOWED_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣]+$"); // 영어,숫자,한글 가능
 
@@ -21,7 +20,7 @@ public record AdminName(
     }
 
     private void validateLength(final String adminName) {
-        if(adminName.length() < MIN_LENGTH || adminName.length() > MAX_LENGTH)
+        if(adminName.isEmpty() || adminName.length() > MAX_LENGTH)
             throw new InvalidAdminNameException("adminName = " + adminName + " length = " + adminName.length());
     }
 

--- a/backend/src/main/java/feedzupzup/backend/admin/domain/vo/LoginId.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/domain/vo/LoginId.java
@@ -11,6 +11,7 @@ public record LoginId(
         String value
 ) {
 
+    private static final int MIN_LENGTH = 5;
     private static final int MAX_LENGTH = 10;
     private static final String BLANK_SPACE = " ";
     private static final Pattern ALLOWD_LOGIN_PATTERN = Pattern.compile("^[a-zA-Z0-9]+$"); // 영여, 숫자만 가능
@@ -21,7 +22,7 @@ public record LoginId(
     }
 
     private void validateLength(final String loginId) {
-        if (loginId.isEmpty() || loginId.length() > MAX_LENGTH) {
+        if (loginId.length() < MIN_LENGTH || loginId.length() > MAX_LENGTH) {
             throw new InvalidAdminIdException("loginId = " + loginId + " length = " + loginId.length());
         }
     }

--- a/backend/src/test/java/feedzupzup/backend/admin/domain/fixture/AdminFixture.java
+++ b/backend/src/test/java/feedzupzup/backend/admin/domain/fixture/AdminFixture.java
@@ -11,14 +11,14 @@ public class AdminFixture {
         return new Admin(
                 new LoginId("admin123"),
                 new EncodedPassword("password123"),
-                new AdminName("lisab"));
+                new AdminName("lisa"));
     }
 
     public static Admin createFromLoginId(final String loginId) {
         return new Admin(
                 new LoginId(loginId),
                 new EncodedPassword("password123"),
-                new AdminName("lisab"));
+                new AdminName("lisa"));
     }
 
 }


### PR DESCRIPTION
## 😉 연관 이슈
#916 

## 🚀 작업 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선사항
* 관리자 이름의 최대 길이 제한을 20자로 확대했습니다.
* 로그인 ID에 최소 5자 이상의 길이 요구사항을 추가하여 입력 유효성 검사를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->