### PR TITLE
[BE] fix: 클러스터 내 모든 피드백 삭제시 빈값 반환

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
@@ -143,11 +143,8 @@ public class AdminFeedbackService {
     public ClusterFeedbacksResponse getFeedbacksByClusterId(final Long clusterId) {
         final EmbeddingCluster embeddingCluster = embeddingClusterRepository.findById(clusterId)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 clusterid(id = " + clusterId + ")로 찾을 수 없습니다."));
-        final List<FeedbackEmbeddingCluster> embeddingClusters = feedbackEmbeddingClusterRepository.findAllByEmbeddingCluster(
+        final List<FeedbackEmbeddingCluster> feedbackEmbeddingClusters = feedbackEmbeddingClusterRepository.findAllByEmbeddingCluster(
                 embeddingCluster);
-        if (embeddingClusters.isEmpty()) {
-            throw new ResourceNotFoundException("해당 클러스터 ID(clusterID = " + clusterId + ")를 가진 피드백은 존재하지 않습니다.");
-        }
-        return ClusterFeedbacksResponse.of(embeddingClusters, embeddingCluster.getLabel());
+        return ClusterFeedbacksResponse.of(feedbackEmbeddingClusters, embeddingCluster.getLabel());
     }
 }


### PR DESCRIPTION
## 😉 연관 이슈
#919 

## 🚀 작업 내용
클러스터 내 모든 피드백 삭제시 예외가 발생하는 것을 빈값 반환하도록 수정했습니다.
플로우상 올바르게~

## 💬 리뷰 중점사항
