### PR TITLE
[BE] fix: 피드백 엑셀 이미지 위치 수정

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
@@ -142,6 +142,9 @@ public class FeedbackPoiExcelExporter implements FeedbackExcelExporter {
             final ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
             anchor.setCol1(IMAGE.columnIndex());
             anchor.setRow1(rowNum);
+            anchor.setCol2(IMAGE.columnIndex() + 1);
+            anchor.setRow2(rowNum + 1);
+            anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_AND_RESIZE);
 
             final Picture picture = sheet.createDrawingPatriarch().createPicture(anchor, pictureIndex);
             picture.resize(1, 1);


### PR DESCRIPTION
## 😉 연관 이슈

#972 

## 🚀 작업 내용

피드백 파일의 이미지가 셀의 올바른 위치에 첨부되지 않는 오류 수정

## 💬 리뷰 중점사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * Excel 피드백 내보내기에서 이미지의 위치 지정 및 크기 조정 동작을 업데이트했습니다. 이미지는 이제 두 셀 범위에 걸쳐 배치되며, 시트 내에서 더 유연하게 크기 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->