### PR TITLE
[BE] refactor: 피드백 이미지 비동기/병렬 다운로드 및 백프레셔 제어

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackExcelColumn.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackExcelColumn.java
@@ -2,24 +2,26 @@ package feedzupzup.backend.feedback.infrastructure.excel;
 
 public enum FeedbackExcelColumn {
 
-    FEEDBACK_NUMBER(0, "피드백 번호"),
-    CONTENT(1, "피드백 내용"),
-    CATEGORY(2, "카테고리"),
-    IMAGE(3, "첨부 이미지"),
-    LIKE_COUNT(4, "좋아요 수"),
-    IS_SECRET(5, "비밀글 여부"),
-    STATUS(6, "처리 상태"),
-    COMMENT(7, "관리자 답변"),
-    USER_NAME(8, "작성자 닉네임"),
-    POSTED_AT(9, "작성 일시"),
+    FEEDBACK_NUMBER(0, "피드백 번호", 4000),
+    CONTENT(1, "피드백 내용", 4000),
+    CATEGORY(2, "카테고리", 4000),
+    IMAGE(3, "첨부 이미지", 10000),
+    LIKE_COUNT(4, "좋아요 수", 4000),
+    IS_SECRET(5, "비밀글 여부", 4000),
+    STATUS(6, "처리 상태", 4000),
+    COMMENT(7, "관리자 답변", 4000),
+    USER_NAME(8, "작성자 닉네임", 4000),
+    POSTED_AT(9, "작성 일시", 6000),
     ;
 
     private final int columnIndex;
     private final String headerName;
+    private final int columnWidth;
 
-    FeedbackExcelColumn(int columnIndex, String headerName) {
+    FeedbackExcelColumn(int columnIndex, String headerName, int columnWidth) {
         this.columnIndex = columnIndex;
         this.headerName = headerName;
+        this.columnWidth = columnWidth;
     }
 
     public int columnIndex() {
@@ -28,5 +30,9 @@ public enum FeedbackExcelColumn {
 
     public String headerName() {
         return headerName;
+    }
+
+    public int columnWidth() {
+        return columnWidth;
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackExcelColumn.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackExcelColumn.java
@@ -1,4 +1,4 @@
-package feedzupzup.backend.feedback.domain;
+package feedzupzup.backend.feedback.infrastructure.excel;
 
 public enum FeedbackExcelColumn {
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackExcelColumn.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackExcelColumn.java
@@ -18,7 +18,7 @@ public enum FeedbackExcelColumn {
     private final String headerName;
     private final int columnWidth;
 
-    FeedbackExcelColumn(int columnIndex, String headerName, int columnWidth) {
+    FeedbackExcelColumn(final int columnIndex, final String headerName, final int columnWidth) {
         this.columnIndex = columnIndex;
         this.headerName = headerName;
         this.columnWidth = columnWidth;

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageConsumer.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageConsumer.java
@@ -36,7 +36,6 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 @Slf4j
 public class FeedbackImageConsumer {
 
-    private static final int IMAGE_COLUMN_WIDTH = 10000;
     private static final short DEFAULT_ROW_HEIGHT = 300;
 
     private final Sheet sheet;
@@ -112,7 +111,7 @@ public class FeedbackImageConsumer {
         }
 
         try {
-            sheet.setColumnWidth(IMAGE.columnIndex(), IMAGE_COLUMN_WIDTH);
+            sheet.setColumnWidth(IMAGE.columnIndex(), IMAGE.columnWidth());
             adjustRowHeightByImageRatio(row, imageResult.imageData());
             insertImageToPicture(imageResult.imageData(), rowNum);
         } catch (IOException e) {
@@ -140,7 +139,7 @@ public class FeedbackImageConsumer {
         final int imageHeight = bufferedImage.getHeight();
 
         final double aspectRatio = (double) imageHeight / imageWidth;
-        final int pixelWidth = (IMAGE_COLUMN_WIDTH / 256) * 7;
+        final int pixelWidth = (IMAGE.columnWidth() / 256) * 7;
         final short rowHeight = (short) (pixelWidth * aspectRatio * 20);
 
         row.setHeight(rowHeight);

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageConsumer.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageConsumer.java
@@ -1,0 +1,173 @@
+package feedzupzup.backend.feedback.infrastructure.excel;
+
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.CATEGORY;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.COMMENT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.CONTENT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.FEEDBACK_NUMBER;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.IMAGE;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.IS_SECRET;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.LIKE_COUNT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.POSTED_AT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.STATUS;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.USER_NAME;
+
+import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.global.exception.InfrastructureException.PoiExcelExportException;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.concurrent.BlockingQueue;
+import javax.imageio.ImageIO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Picture;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+
+@RequiredArgsConstructor
+@Slf4j
+public class FeedbackImageConsumer {
+
+    private static final int IMAGE_COLUMN_WIDTH = 10000;
+    private static final short DEFAULT_ROW_HEIGHT = 300;
+
+    private final Sheet sheet;
+    private final BlockingQueue<FeedbackWithImage> queue;
+    private final SXSSFWorkbook workbook;
+
+    void consumeToExcel(final int totalCount) {
+        int rowNum = 1;
+        int feedbackNum = 1;
+        int processedCount = 0;
+
+        try {
+            while (true) {
+                final FeedbackWithImage item = queue.take();
+
+                if (item.isPoisonPill()) {
+                    break;
+                }
+
+                final Row row = sheet.createRow(rowNum);
+                addFeedbackToRow(row, item.feedback(), item.imageResult(), feedbackNum, rowNum);
+
+                rowNum++;
+                feedbackNum++;
+                processedCount++;
+
+                if (processedCount % 10 == 0 || processedCount == totalCount) {
+                    log.info("엑셀 작성 진행: {}/{}", processedCount, totalCount);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PoiExcelExportException("엑셀 파일 생성이 중단되었습니다.");
+        }
+    }
+
+    private void addFeedbackToRow(
+            final Row row,
+            final Feedback feedback,
+            final ImageDownloadResult imageResult,
+            final int feedbackNum,
+            final int rowNum
+    ) {
+        row.createCell(FEEDBACK_NUMBER.columnIndex()).setCellValue(feedbackNum);
+        row.createCell(CONTENT.columnIndex()).setCellValue(feedback.getContent().getValue());
+        row.createCell(CATEGORY.columnIndex())
+                .setCellValue(feedback.getOrganizationCategory().getCategory().getKoreanName());
+
+        addImageCell(row, imageResult, rowNum);
+
+        row.createCell(LIKE_COUNT.columnIndex()).setCellValue(feedback.getLikeCountValue());
+        row.createCell(IS_SECRET.columnIndex()).setCellValue(feedback.isSecret() ? "Y" : "N");
+        row.createCell(STATUS.columnIndex()).setCellValue(feedback.getStatus().name());
+        row.createCell(COMMENT.columnIndex())
+                .setCellValue(feedback.getComment() == null ? "" : feedback.getComment().getValue());
+        row.createCell(USER_NAME.columnIndex()).setCellValue(feedback.getUserName().getValue());
+        addDateCell(row, feedback.getPostedAt().getValue());
+    }
+
+    private void addImageCell(
+            final Row row,
+            final ImageDownloadResult imageResult,
+            final int rowNum
+    ) {
+        if (imageResult.isNoImage()) {
+            setEmptyImageCell(row);
+            return;
+        }
+
+        if (imageResult.isFailed()) {
+            setFailedImageCell(row, "이미지 로드 실패");
+            return;
+        }
+
+        try {
+            sheet.setColumnWidth(IMAGE.columnIndex(), IMAGE_COLUMN_WIDTH);
+            adjustRowHeightByImageRatio(row, imageResult.imageData());
+            insertImageToPicture(imageResult.imageData(), rowNum);
+        } catch (IOException e) {
+            setFailedImageCell(row, "이미지 로드 실패");
+            log.error("이미지 로드 실패", e);
+        } catch (Exception e) {
+            setFailedImageCell(row, "이미지 삽입 실패");
+            log.error("엑셀에 이미지 삽입 실패", e);
+        }
+    }
+
+    private void setEmptyImageCell(final Row row) {
+        row.createCell(IMAGE.columnIndex()).setCellValue("");
+        row.setHeight(DEFAULT_ROW_HEIGHT);
+    }
+
+    private void setFailedImageCell(final Row row, final String message) {
+        row.createCell(IMAGE.columnIndex()).setCellValue(message);
+        row.setHeight(DEFAULT_ROW_HEIGHT);
+    }
+
+    private void adjustRowHeightByImageRatio(final Row row, final byte[] imageData) throws IOException {
+        final BufferedImage bufferedImage = ImageIO.read(new ByteArrayInputStream(imageData));
+        final int imageWidth = bufferedImage.getWidth();
+        final int imageHeight = bufferedImage.getHeight();
+
+        final double aspectRatio = (double) imageHeight / imageWidth;
+        final int pixelWidth = (IMAGE_COLUMN_WIDTH / 256) * 7;
+        final short rowHeight = (short) (pixelWidth * aspectRatio * 20);
+
+        row.setHeight(rowHeight);
+    }
+
+    private void insertImageToPicture(final byte[] imageData, final int rowNum) {
+        final int pictureIndex = workbook.addPicture(imageData, Workbook.PICTURE_TYPE_JPEG);
+
+        final ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
+        anchor.setCol1(IMAGE.columnIndex());
+        anchor.setRow1(rowNum);
+        anchor.setCol2(IMAGE.columnIndex() + 1);
+        anchor.setRow2(rowNum + 1);
+        anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_AND_RESIZE);
+
+        final Picture picture = sheet.createDrawingPatriarch().createPicture(anchor, pictureIndex);
+        picture.resize(1.0, 1.0);
+    }
+
+    private void addDateCell(final Row row, final LocalDateTime dateTime) {
+        final Cell cell = row.createCell(POSTED_AT.columnIndex());
+        final Date date = Date.from(dateTime.atZone(java.time.ZoneId.systemDefault()).toInstant());
+        cell.setCellValue(date);
+
+        final CellStyle dateStyle = workbook.createCellStyle();
+        final CreationHelper creationHelper = workbook.getCreationHelper();
+        dateStyle.setDataFormat(creationHelper.createDataFormat().getFormat("yyyy-mm-dd hh:mm:ss"));
+        cell.setCellStyle(dateStyle);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageProducer.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageProducer.java
@@ -1,0 +1,76 @@
+package feedzupzup.backend.feedback.infrastructure.excel;
+
+import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.s3.service.S3DownloadService;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class FeedbackImageProducer {
+
+    private final S3DownloadService s3DownloadService;
+    private final BlockingQueue<FeedbackWithImage> queue;
+    private final ExecutorService executor;
+
+    public CompletableFuture<Void> produceImages(final List<Feedback> feedbacks) {
+        return CompletableFuture.runAsync(() -> {
+            final List<CompletableFuture<Void>> downloadJobs = feedbacks.stream()
+                    .map(this::downloadJob)
+                    .toList();
+
+            CompletableFuture.allOf(downloadJobs.toArray(CompletableFuture[]::new)).join();
+
+            notifyFinished();
+        }, executor);
+    }
+
+    private CompletableFuture<Void> downloadJob(final Feedback feedback) {
+        return CompletableFuture
+                .supplyAsync(() -> downloadImage(feedback), executor)
+                .thenAccept(imageResult -> enqueue(feedback, imageResult))
+                .exceptionally(ex -> {
+                    log.error("이미지 다운로드 실패", ex);
+                    enqueue(feedback, ImageDownloadResult.failed());
+                    return null;
+                });
+    }
+
+    private void enqueue(final Feedback feedback, final ImageDownloadResult imageResult) {
+        try {
+            queue.put(new FeedbackWithImage(feedback, imageResult));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CompletionException("Queue 추가 실패", e);
+        }
+    }
+
+    private ImageDownloadResult downloadImage(final Feedback feedback) {
+        if (feedback.getImageUrl() == null) {
+            return ImageDownloadResult.noImage();
+        }
+
+        try {
+            final String imageUrl = feedback.getImageUrl().getValue();
+            final byte[] imageData = s3DownloadService.downloadFile(imageUrl);
+            return ImageDownloadResult.success(imageData);
+        } catch (Exception e) {
+            log.error("이미지 다운로드 실패: {}", feedback.getImageUrl(), e);
+            return ImageDownloadResult.failed();
+        }
+    }
+
+    private void notifyFinished() {
+        try {
+            queue.put(FeedbackWithImage.POISON_PILL);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CompletionException("종료 신호 전송 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageProducer.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackImageProducer.java
@@ -20,13 +20,15 @@ public class FeedbackImageProducer {
 
     public CompletableFuture<Void> produceImages(final List<Feedback> feedbacks) {
         return CompletableFuture.runAsync(() -> {
-            final List<CompletableFuture<Void>> downloadJobs = feedbacks.stream()
-                    .map(this::downloadJob)
-                    .toList();
+            try {
+                final List<CompletableFuture<Void>> downloadJobs = feedbacks.stream()
+                        .map(this::downloadJob)
+                        .toList();
 
-            CompletableFuture.allOf(downloadJobs.toArray(CompletableFuture[]::new)).join();
-
-            notifyFinished();
+                CompletableFuture.allOf(downloadJobs.toArray(CompletableFuture[]::new)).join();
+            } finally {
+                notifyFinished();
+            }
         }, executor);
     }
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
@@ -105,7 +105,7 @@ public class FeedbackPoiExcelExporter implements FeedbackExcelExporter {
             produceJob.join();
         } catch (CompletionException e) {
             log.error("이미지 다운로드 작업 중 오류 발생", e);
-            throw new PoiExcelExportException("이미지 다운로드 중 오류가 발생했습니다.");
+            throw new PoiExcelExportException("이미지 다운로드 중 오류가 발생했습니다.", e);
         }
     }
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
@@ -98,7 +98,7 @@ public class FeedbackPoiExcelExporter implements FeedbackExcelExporter {
         final FeedbackImageProducer producer = new FeedbackImageProducer(s3DownloadService, queue, executor);
         final CompletableFuture<Void> produceJob = producer.produceImages(feedbacks);
 
-        final FeedbackImageConsumer consumer = new FeedbackImageConsumer(sheet, queue, workbook);
+        final FeedbackRowWriter consumer = new FeedbackRowWriter(sheet, queue, workbook);
         consumer.consumeToExcel(feedbacks.size());
 
         try {

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
@@ -82,7 +82,7 @@ public class FeedbackPoiExcelExporter implements FeedbackExcelExporter {
             cell.setCellValue(column.headerName());
             cell.setCellStyle(headerStyle);
 
-            final int columnWidth = 4000;
+            final int columnWidth = column.columnWidth();
             sheet.setColumnWidth(column.columnIndex(), columnWidth);
         }
     }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporter.java
@@ -1,18 +1,6 @@
 package feedzupzup.backend.feedback.infrastructure.excel;
 
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.CATEGORY;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.COMMENT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.CONTENT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.FEEDBACK_NUMBER;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.IMAGE;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.IS_SECRET;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.LIKE_COUNT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.POSTED_AT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.STATUS;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.USER_NAME;
-
 import feedzupzup.backend.feedback.domain.Feedback;
-import feedzupzup.backend.feedback.domain.FeedbackExcelColumn;
 import feedzupzup.backend.feedback.domain.FeedbackExcelExporter;
 import feedzupzup.backend.global.exception.InfrastructureException.PoiExcelExportException;
 import feedzupzup.backend.organization.domain.Organization;
@@ -20,19 +8,22 @@ import feedzupzup.backend.s3.service.S3DownloadService;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.IndexedColors;
-import org.apache.poi.ss.usermodel.Picture;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.springframework.stereotype.Component;
 
@@ -40,6 +31,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class FeedbackPoiExcelExporter implements FeedbackExcelExporter {
+
+    private static final int QUEUE_CAPACITY = 15;
+    private static final int PRODUCER_THREAD = 1;
+    private static final int DOWNLOAD_THREADS = 10;
 
     private final S3DownloadService s3DownloadService;
 
@@ -49,108 +44,83 @@ public class FeedbackPoiExcelExporter implements FeedbackExcelExporter {
             final List<Feedback> feedbacks,
             final OutputStream outputStream
     ) {
+        log.info("피드백 엑셀 다운로드 시작: 조직={}, 피드백 개수={}", organization.getName().getValue(), feedbacks.size());
+
         final int windowSize = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool(PRODUCER_THREAD + DOWNLOAD_THREADS);
+
         try (final SXSSFWorkbook workbook = new SXSSFWorkbook(windowSize)) {
             final String sheetName = organization.getName().getValue();
-            final SXSSFSheet sheet = workbook.createSheet(sheetName);
+            final Sheet sheet = workbook.createSheet(sheetName);
 
-            addFeedbackHeaderRow(sheet);
-            addFeedbackDataRows(sheet, workbook, feedbacks);
+            createHeaderRow(sheet);
+            createDataRows(sheet, workbook, feedbacks, executor);
 
             workbook.write(outputStream);
             outputStream.flush();
+
+            log.info("피드백 엑셀 다운로드 완료");
         } catch (IOException e) {
             throw new PoiExcelExportException("엑셀 파일 생성 중 오류가 발생했습니다.");
+        } finally {
+            shutdownExecutor(executor);
         }
     }
 
-    private void addFeedbackHeaderRow(final Sheet sheet) {
-        final Workbook workbook = sheet.getWorkbook();
-
-        final CellStyle headerStyle = workbook.createCellStyle();
-        final Font font = workbook.createFont();
+    private void createHeaderRow(final Sheet sheet) {
+        final CellStyle headerStyle = sheet.getWorkbook().createCellStyle();
+        final Font font = sheet.getWorkbook().createFont();
         font.setBold(true);
         headerStyle.setFont(font);
         headerStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
         headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
 
-        final int startRowNum = 0;
-        final Row headerRow = sheet.createRow(startRowNum);
+        final Row headerRow = sheet.createRow(0);
 
         for (final FeedbackExcelColumn column : FeedbackExcelColumn.values()) {
             final Cell cell = headerRow.createCell(column.columnIndex());
             cell.setCellValue(column.headerName());
             cell.setCellStyle(headerStyle);
 
-            int columnWidth = 4000;
+            final int columnWidth = 4000;
             sheet.setColumnWidth(column.columnIndex(), columnWidth);
         }
     }
 
-    private void addFeedbackDataRows(
+    private void createDataRows(
             final Sheet sheet,
             final SXSSFWorkbook workbook,
-            final List<Feedback> feedbacks
+            final List<Feedback> feedbacks,
+            final ExecutorService executor
     ) {
-        int rowNum = 1;
-        int feedbackNum = 1;
-        for (final Feedback feedback : feedbacks) {
-            final Row row = sheet.createRow(rowNum);
+        final BlockingQueue<FeedbackWithImage> queue = new ArrayBlockingQueue<>(QUEUE_CAPACITY);
 
-            row.createCell(FEEDBACK_NUMBER.columnIndex()).setCellValue(feedbackNum++);
-            row.createCell(CONTENT.columnIndex()).setCellValue(feedback.getContent().getValue());
-            row.createCell(CATEGORY.columnIndex())
-                    .setCellValue(feedback.getOrganizationCategory().getCategory().getKoreanName());
+        final FeedbackImageProducer producer = new FeedbackImageProducer(s3DownloadService, queue, executor);
+        final CompletableFuture<Void> produceJob = producer.produceImages(feedbacks);
 
-            addImageCell(sheet, workbook, row, feedback, rowNum);
+        final FeedbackImageConsumer consumer = new FeedbackImageConsumer(sheet, queue, workbook);
+        consumer.consumeToExcel(feedbacks.size());
 
-            row.createCell(LIKE_COUNT.columnIndex()).setCellValue(feedback.getLikeCountValue());
-            row.createCell(IS_SECRET.columnIndex()).setCellValue(feedback.isSecret() ? "Y" : "N");
-            row.createCell(STATUS.columnIndex()).setCellValue(feedback.getStatus().name());
-            row.createCell(COMMENT.columnIndex())
-                    .setCellValue(feedback.getComment() == null ? "" : feedback.getComment().getValue());
-            row.createCell(USER_NAME.columnIndex()).setCellValue(feedback.getUserName().getValue());
-            row.createCell(POSTED_AT.columnIndex()).setCellValue(feedback.getPostedAt().getValue().toString());
-
-            rowNum++;
+        try {
+            produceJob.join();
+        } catch (CompletionException e) {
+            log.error("이미지 다운로드 작업 중 오류 발생", e);
+            throw new PoiExcelExportException("이미지 다운로드 중 오류가 발생했습니다.");
         }
     }
 
-    /**
-     * s3에서 이미지를 다운받아 엑셀의 Cell에 삽입한다.
-     * <p>
-     * 참고 - 이미지 다운이 실패하더라도 엑셀 다운로드는 성공시키기 위해 예외를 던지지 않음
-     */
-    private void addImageCell(
-            final Sheet sheet,
-            final SXSSFWorkbook workbook,
-            final Row row,
-            final Feedback feedback,
-            final int rowNum
-    ) {
-        if (feedback.getImageUrl() == null) {
-            row.createCell(IMAGE.columnIndex()).setCellValue("");
-            return;
-        }
-
+    private void shutdownExecutor(final ExecutorService executor) {
         try {
-            final String imageUrl = feedback.getImageUrl().getValue();
-            final byte[] imageData = s3DownloadService.downloadFile(imageUrl);
-
-            final int pictureIndex = workbook.addPicture(imageData, Workbook.PICTURE_TYPE_JPEG);
-
-            final ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
-            anchor.setCol1(IMAGE.columnIndex());
-            anchor.setRow1(rowNum);
-            anchor.setCol2(IMAGE.columnIndex() + 1);
-            anchor.setRow2(rowNum + 1);
-            anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_AND_RESIZE);
-
-            final Picture picture = sheet.createDrawingPatriarch().createPicture(anchor, pictureIndex);
-            picture.resize(1, 1);
-        } catch (Exception e) {
-            row.createCell(IMAGE.columnIndex()).setCellValue("이미지 로드 실패");
-            log.error("엑셀 파일 생성을 위한 이미지 다운로드 실패", e);
+            executor.shutdown();
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    log.error("Executor 강제 종료 실패");
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackRowWriter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackRowWriter.java
@@ -140,7 +140,8 @@ public class FeedbackRowWriter {
 
         final double aspectRatio = (double) imageHeight / imageWidth;
         final int pixelWidth = (IMAGE.columnWidth() / 256) * 7;
-        final short rowHeight = (short) (pixelWidth * aspectRatio * 20);
+        final double height = pixelWidth * aspectRatio * 20;
+        final short rowHeight = (short) Math.min(Short.MAX_VALUE, height);
 
         row.setHeight(rowHeight);
     }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackRowWriter.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackRowWriter.java
@@ -34,7 +34,7 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 @RequiredArgsConstructor
 @Slf4j
-public class FeedbackImageConsumer {
+public class FeedbackRowWriter {
 
     private static final short DEFAULT_ROW_HEIGHT = 300;
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackWithImage.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackWithImage.java
@@ -1,0 +1,12 @@
+package feedzupzup.backend.feedback.infrastructure.excel;
+
+import feedzupzup.backend.feedback.domain.Feedback;
+
+record FeedbackWithImage(Feedback feedback, ImageDownloadResult imageResult, boolean isPoisonPill) {
+
+    static final FeedbackWithImage POISON_PILL = new FeedbackWithImage(null, null, true);
+
+    FeedbackWithImage(final Feedback feedback, final ImageDownloadResult imageResult) {
+        this(feedback, imageResult, false);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/ImageDownloadResult.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/excel/ImageDownloadResult.java
@@ -1,0 +1,28 @@
+package feedzupzup.backend.feedback.infrastructure.excel;
+
+record ImageDownloadResult(byte[] imageData, ResultType type) {
+
+    enum ResultType {
+        SUCCESS, FAILED, NO_IMAGE
+    }
+
+    static ImageDownloadResult success(final byte[] imageData) {
+        return new ImageDownloadResult(imageData, ResultType.SUCCESS);
+    }
+
+    static ImageDownloadResult failed() {
+        return new ImageDownloadResult(null, ResultType.FAILED);
+    }
+
+    static ImageDownloadResult noImage() {
+        return new ImageDownloadResult(null, ResultType.NO_IMAGE);
+    }
+
+    boolean isFailed() {
+        return type == ResultType.FAILED;
+    }
+
+    boolean isNoImage() {
+        return type == ResultType.NO_IMAGE;
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporterTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/infrastructure/excel/FeedbackPoiExcelExporterTest.java
@@ -1,16 +1,16 @@
 package feedzupzup.backend.feedback.infrastructure.excel;
 
 import static feedzupzup.backend.category.domain.Category.SUGGESTION;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.CATEGORY;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.COMMENT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.CONTENT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.FEEDBACK_NUMBER;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.IMAGE;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.IS_SECRET;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.LIKE_COUNT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.POSTED_AT;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.STATUS;
-import static feedzupzup.backend.feedback.domain.FeedbackExcelColumn.USER_NAME;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.CATEGORY;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.COMMENT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.CONTENT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.FEEDBACK_NUMBER;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.IMAGE;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.IS_SECRET;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.LIKE_COUNT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.POSTED_AT;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.STATUS;
+import static feedzupzup.backend.feedback.infrastructure.excel.FeedbackExcelColumn.USER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;


### PR DESCRIPTION
## 😉 연관 이슈
#987

## 🚀 작업 내용

### Producer-Consumer 패턴 + 배압 제어(Backpressure)

이미지 다운로드와 Excel 작성을 독립적인 작업 흐름으로 분리하고, BlockingQueue를 통해 배압 제어를 구현했습니다.

#### 작업 흐름

1. S3 이미지 소스
2. FeedbackImageProducer (생산자)
    - 10개 스레드 병렬 다운로드
3. BlockingQueue (용량: 15) ← 배압 제어 지점
4. FeedbackRowWriter (소비자)
    - 순차적으로 Excel 작성

#### FeedbackImageProducer (생산자)
- 별도 스레드 풀(10개)에서 S3 이미지 병렬 다운로드
- 다운로드 완료 즉시 BlockingQueue에 `FeedbackWithImage` 객체 추가
- 다운로드 실패 시에도 `ImageDownloadResult.failed()`를 큐에 전달
- 모든 다운로드 완료 후 `Poison Pill` 신호를 큐에 추가 → Consumer에 종료 신호

#### FeedbackRowWriter (소비자)
- BlockingQueue에서 `FeedbackWithImage` 객체를 순차적으로 수신
- 각 아이템에 대해 다음 처리 수행:
  - Excel Row에 피드백 데이터 및 이미지 삽입
- `Poison Pill` 수신 → 처리 완료 및 종료

**배압 제어를 구현한 이유**
  
- **OOM 방지**: Producer가 무한정 빠르게 진행되지 않음
  - 큐가 가득 찰 때까지만 다운로드 → 시스템 리소스 예측 가능, 네트워크 속도가 매우 빨라도 메모리는 안정적
  - 배압이 없다면 100개 이미지가 모두 다운로드되면 메모리 사용량 = 이미지 100개 크기
  
- **리소스 효율**: Producer 스레드가 불필요한 작업 방지
  - 큐가 가득 차면 대기 → CPU 낭비 없음
  
- **네트워크 안정성**: 지연 발생 시 자동 조절
  - Consumer가 느려짐 → 큐 채움 → Producer 대기
  - 시스템 전체가 안정적으로 감속

**용량 결정 근거 (15)**
- 1-5개: Producer 자주 블로킹 → 병렬 이점 감소
- 10-20개: Producer 병렬성 유지 + 메모리 제한
- 100개 이상: 배압 효과 감소 → OOM 위험 증가
- 15개 → 10개 병렬 다운로드 스레드의 1-2배 버퍼 제공

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * Excel 내보내기 기능이 개선되어 더 빠르고 안정적인 이미지 처리가 가능해졌습니다.
  * 대용량 피드백 데이터 내보내기 시 동시 이미지 다운로드를 통해 성능이 향상되었습니다.

* **버그 수정**
  * 이미지 다운로드 실패 시 더 강화된 오류 처리 로직이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->