### PR TITLE
fix: 회원가입 안되는 문제 해결

### DIFF
--- a/frontend/src/domains/admin/SignUp/SignUp.tsx
+++ b/frontend/src/domains/admin/SignUp/SignUp.tsx
@@ -122,7 +122,7 @@ export default function SignUp() {
               );
             })}
           </div>
-          <BasicButton disabled={isLoading} aria-busy={isLoading}>
+          <BasicButton type='submit' disabled={isLoading} aria-busy={isLoading}>
             계정 만들기
           </BasicButton>
           <div css={signUpCaptionContainer(theme)}>


### PR DESCRIPTION
## 😉 연관 이슈
#1008 

## 🚀 작업 내용
회원가입 안 되던 원인: BasicButton 기본 type이 리팩터링 중 'button'으로 바뀌면서, SignUp 페이지 버튼이 `<button type="button">`으로 렌더링됐고 폼 onSubmit이 호출되지 않음.


BasicButton에서 type='button' 을 유지해야하는 이유: 제출이 필요한 버튼에만 type='submit'을 명시하게 해 의도가 분명해지는것. 말고도 의도치 않은 제출 막기.

`frontend/src/domains/admin/SignUp/SignUp.tsx`의 “계정 만들기” 버튼에 type='submit'을 추가해 폼이 다시 정상 제출되도록 함.

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 회원가입 폼의 제출 버튼이 이제 올바르게 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->