### PR TITLE
[BE] refactor: 다중 서버에서의 Scheduling 가능하도록 수정

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/global/config/SpringSchedulerConfig.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/SpringSchedulerConfig.java
@@ -1,10 +1,21 @@
 package feedzupzup.backend.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class SpringSchedulerConfig {
 
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(3);
+        scheduler.setThreadNamePrefix("scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/global/domain/LockRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/global/domain/LockRepository.java
@@ -1,0 +1,17 @@
+package feedzupzup.backend.global.domain;
+
+import feedzupzup.backend.guest.domain.guest.Guest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+// Guest는 단순한 껍데기 입니다. JPA 문법 상 객체가 필요해, 임의로 Guest로 설정했습니다.
+public interface LockRepository extends JpaRepository<Guest, Long> {
+
+    @Query(value = "SELECT GET_LOCK(:key, :timeoutSeconds)", nativeQuery = true)
+    Integer getLock(@Param("key") String key, @Param("timeoutSeconds") int timeoutSeconds);
+
+    @Query(value = "SELECT RELEASE_LOCK(:key)", nativeQuery = true)
+    Integer releaseLock(@Param("key") String key);
+
+}

--- a/backend/src/main/java/feedzupzup/backend/global/domain/RetryExecutor.java
+++ b/backend/src/main/java/feedzupzup/backend/global/domain/RetryExecutor.java
@@ -1,0 +1,33 @@
+package feedzupzup.backend.global.domain;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RetryExecutor {
+
+    public static void execute(
+            final ThrowingSupplier<Boolean> action,
+            final int maxRetries,
+            final long delayMs,
+            final String taskName
+    ) {
+        for (int i = 1; i <= maxRetries; i++) {
+            try {
+                boolean isSuccess = action.get();
+                if (isSuccess) {
+                    log.info(taskName + " 작업 성공");
+                }
+            } catch (Exception e) {
+                log.warn("[{}] 에러 발생으로 인한 재시도 (시도: {}/{}) - {}", taskName, i, maxRetries,
+                        e.getMessage());
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        log.error("[{}] 최대 재시도 횟수({}) 초과. 실패.", taskName, maxRetries);
+    }
+
+}

--- a/backend/src/main/java/feedzupzup/backend/global/domain/RetryExecutor.java
+++ b/backend/src/main/java/feedzupzup/backend/global/domain/RetryExecutor.java
@@ -16,6 +16,7 @@ public class RetryExecutor {
                 boolean isSuccess = action.get();
                 if (isSuccess) {
                     log.info(taskName + " 작업 성공");
+                    return;
                 }
             } catch (Exception e) {
                 log.warn("[{}] 에러 발생으로 인한 재시도 (시도: {}/{}) - {}", taskName, i, maxRetries,

--- a/backend/src/main/java/feedzupzup/backend/global/domain/ThrowingSupplier.java
+++ b/backend/src/main/java/feedzupzup/backend/global/domain/ThrowingSupplier.java
@@ -1,0 +1,6 @@
+package feedzupzup.backend.global.domain;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+    T get() throws Exception;
+}

--- a/backend/src/main/java/feedzupzup/backend/guest/application/GuestService.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/application/GuestService.java
@@ -12,6 +12,7 @@ import feedzupzup.backend.guest.domain.like.LikeHistory;
 import feedzupzup.backend.guest.domain.like.LikeHistoryRepository;
 import feedzupzup.backend.guest.domain.write.WriteHistory;
 import feedzupzup.backend.guest.domain.write.WriteHistoryRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -25,6 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class GuestService {
+
+    private static final String GUEST_REMOVE_KEY = "guest_remove_lock";
+    private static final String GUEST_STATUS_UPDATE_KEY = "guest_last_connected_lock";
 
     private final GuestRepository guestRepository;
     private final WriteHistoryRepository writeHistoryRepository;
@@ -61,19 +65,49 @@ public class GuestService {
     }
 
     @Transactional
-    public boolean processUpdateWithLock(final String lockKey, final Set<UUID> activeGuests) {
-        Integer result = lockRepository.getLock(lockKey, 60);
+    public boolean processUpdateWithLock() {
+        Integer result = lockRepository.getLock(GUEST_STATUS_UPDATE_KEY, 30);
         if (result != null && result == 1) {
             try {
-                guestRepository.updateConnectedTimeForGuests(activeGuests, CurrentDateTime.create());
+                final Set<UUID> activeGuests = guestActiveTracker.getTodayActiveGuests();
+                if (activeGuests.isEmpty()) {
+                    log.info("금일 접속 사용자 수가 없습니다.");
+                    return true;
+                }
+                final int updateGuestsCount = guestRepository.updateConnectedTimeForGuests(
+                        activeGuests,
+                        CurrentDateTime.create()
+                );
+                log.info("금일 접속 사용자 수 : " + updateGuestsCount);
                 guestActiveTracker.clear();
                 return true;
             } finally {
-                lockRepository.releaseLock(lockKey);
+                lockRepository.releaseLock(GUEST_STATUS_UPDATE_KEY);
             }
-        } else {
-            log.error("락 획득 실패 (timeout)");
-            return false;
         }
+        log.error("락 획득 실패 (timeout)");
+        return false;
+    }
+
+    @Transactional
+    public int removeUnActiveGuest() {
+        Integer result = lockRepository.getLock(GUEST_REMOVE_KEY, 0);
+        if (result != null && result == 1) {
+            try {
+                final LocalDateTime targetDateTime = CurrentDateTime.create().minusMonths(3);
+                final List<Long> unActivateGuests = guestRepository.findAllByConnectedTimeBefore(
+                        targetDateTime);
+                if (unActivateGuests.isEmpty()) {
+                    return 0;
+                }
+                writeHistoryRepository.deleteByGuestIdIn(unActivateGuests);
+                likeHistoryRepository.deleteByGuestIdIn(unActivateGuests);
+                guestRepository.deleteAllById(unActivateGuests);
+                return unActivateGuests.size();
+            } finally {
+                lockRepository.releaseLock(GUEST_REMOVE_KEY);
+            }
+        }
+        return 0;
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/guest/application/GuestService.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/application/GuestService.java
@@ -79,7 +79,7 @@ public class GuestService {
                         CurrentDateTime.create()
                 );
                 log.info("금일 접속 사용자 수 : " + updateGuestsCount);
-                guestActiveTracker.clear();
+                guestActiveTracker.removeAll(activeGuests);
                 return true;
             } finally {
                 lockRepository.releaseLock(GUEST_STATUS_UPDATE_KEY);

--- a/backend/src/main/java/feedzupzup/backend/guest/domain/guest/GuestActiveTracker.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/domain/guest/GuestActiveTracker.java
@@ -9,5 +9,5 @@ public interface GuestActiveTracker {
 
     Set<UUID> getTodayActiveGuests();
 
-    void clear();
+    void removeAll(Set<UUID> guests);
 }

--- a/backend/src/main/java/feedzupzup/backend/guest/domain/guest/GuestActiveTracker.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/domain/guest/GuestActiveTracker.java
@@ -10,4 +10,6 @@ public interface GuestActiveTracker {
     Set<UUID> getTodayActiveGuests();
 
     void removeAll(Set<UUID> guests);
+
+    void clear();
 }

--- a/backend/src/main/java/feedzupzup/backend/guest/domain/guest/GuestRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/domain/guest/GuestRepository.java
@@ -20,7 +20,7 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
 
     @Modifying
     @Query("UPDATE Guest g SET g.connectedTime = :time WHERE g.guestUuid IN :ids")
-    void updateConnectedTimeForGuests(
+    int updateConnectedTimeForGuests(
             @Param("ids") Set<UUID> ids,
             @Param("time") LocalDateTime time
     );

--- a/backend/src/main/java/feedzupzup/backend/guest/infrastructure/GuestScheduler.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/infrastructure/GuestScheduler.java
@@ -33,7 +33,6 @@ public class GuestScheduler {
         final int deletedCount = guestService.removeUnActiveGuest();
         if (deletedCount == 0) {
             log.info("비활성 유저가 존재하지 않아 스케줄러 작동 패스");
-            log.info("비활성 유저 삭제 스케줄러 작동 완료");
             return;
         }
         log.info("비활성 유저 {}명 삭제 완료", deletedCount);

--- a/backend/src/main/java/feedzupzup/backend/guest/infrastructure/GuestScheduler.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/infrastructure/GuestScheduler.java
@@ -31,10 +31,6 @@ public class GuestScheduler {
     public void removeUnActiveGuest() {
         log.info("비활성 유저 삭제 스케줄러 작동 시작");
         final int deletedCount = guestService.removeUnActiveGuest();
-        if (deletedCount == 0) {
-            log.info("비활성 유저가 존재하지 않아 스케줄러 작동 패스");
-            return;
-        }
         log.info("비활성 유저 {}명 삭제 완료", deletedCount);
         log.info("비활성 유저 삭제 스케줄러 작동 완료");
 

--- a/backend/src/main/java/feedzupzup/backend/guest/infrastructure/InMemoryGuestActiveTracker.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/infrastructure/InMemoryGuestActiveTracker.java
@@ -2,6 +2,7 @@ package feedzupzup.backend.guest.infrastructure;
 
 import feedzupzup.backend.guest.domain.guest.GuestActiveTracker;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,11 +22,11 @@ public class InMemoryGuestActiveTracker implements GuestActiveTracker {
 
     @Override
     public Set<UUID> getTodayActiveGuests() {
-        return Collections.unmodifiableSet(todayActiveGuests);
+        return new HashSet<>(todayActiveGuests);
     }
 
     @Override
-    public void clear() {
-        todayActiveGuests.clear();
+    public void removeAll(Set<UUID> processedGuests) {
+        todayActiveGuests.removeAll(processedGuests);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/guest/infrastructure/InMemoryGuestActiveTracker.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/infrastructure/InMemoryGuestActiveTracker.java
@@ -29,4 +29,9 @@ public class InMemoryGuestActiveTracker implements GuestActiveTracker {
     public void removeAll(Set<UUID> processedGuests) {
         todayActiveGuests.removeAll(processedGuests);
     }
+
+    @Override
+    public void clear() {
+        todayActiveGuests.clear();
+    }
 }


### PR DESCRIPTION
## 😉 연관 이슈
#1012 

## 🚀 작업 내용
다중 서버에서 명확한 Scheduling을 진행하도록 수정

## 💬 리뷰 중점사항
좀 복잡한 부분이 있는데 블로그에 정리해서 올려놓을게요.
11/20 추가: https://codingmasterlsw.tistory.com/67

리뷰하기에 앞서 간단하게 설명하자면, 두 개의 테스크가 있습니다.

1) Guest 삭제
- 이 작업은 두 개의 서버 중 하나만 실행하면 됩니다.
- 삭제 배치 처리는 멱등성을 가지고 있어, 별다른 조치를 안 해도 되지만, 굳이 배치처리 두 번 할 필요는 없기에 진행해봤습니다. 
     - getLock() 사용 시, Lock 걸려있으면, 그냥 return 합니다.
     - shedLock을 사용해도 되지만, 통일성 맞추기 위해 분산락 동일하게 사용했습니다.

2) Guest 상태 업데이트
- 이 경우에는 각 서버의 메모리에 상태가 올라가있기에, 서버 메모리에 있는 값들을 전부 배치 처리 해줘야하는 상황입니다. 
-  MySQL의 getLock()을 사용해 분산락을 적용했습니다. (동시성 문제)
    -  이 경우에, Lock이 걸려있어도 대기큐에서 기다리기 때문에, 배치처리 끝나면, 다음 배치처리를 진행할 수 있습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 분산 잠금 및 DB 기반 잠금 호출 추가로 스케줄 작업 안전성 향상
  * 재시도 유틸리티와 예외 처리 가능한 공급자 인터페이스 도입
  * 스레드풀 기반 스케줄러 초기화(대기·종료 처리 포함) 및 자동 비활성 게스트 정리 기능 추가

* **리팩토링**
  * 게스트 활동 추적 및 스케줄 흐름을 서비스 중심으로 단순화
  * 활동 추적기에 부분 삭제 기능 추가 및 스케줄러의 재시도/종료 흐름 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->