### PR TITLE
[FE] feat: 회원탈퇴 UI 및 연동

### DIFF
--- a/frontend/src/apis/admin.api.ts
+++ b/frontend/src/apis/admin.api.ts
@@ -86,3 +86,7 @@ export async function getAISummaryDetail({
   );
   return response as AISummaryDetailResponse;
 }
+
+export async function deleteAdmin(): Promise<void> {
+  await apiClient.delete('/admin');
+}

--- a/frontend/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Modal from '@/components/Modal/Modal';
 import BasicButton from '@/components/BasicButton/BasicButton';
 import { useAppTheme } from '@/hooks/useAppTheme';
@@ -19,6 +20,8 @@ export interface ConfirmModalProps {
   width?: number;
   height?: number;
   disabled?: boolean;
+  confirmDisabled?: boolean;
+  children?: React.ReactNode;
 }
 
 export default function ConfirmModal({
@@ -31,6 +34,8 @@ export default function ConfirmModal({
   width = 300,
   height,
   disabled = false,
+  confirmDisabled = false,
+  children,
 }: ConfirmModalProps) {
   const theme = useAppTheme();
 
@@ -48,6 +53,7 @@ export default function ConfirmModal({
       <div css={content}>
         <p css={title(theme)}>{confirmTitle}</p>
         {confirmMessage && <p css={message(theme)}>{confirmMessage}</p>}
+        {children}
       </div>
       <div css={buttonContainer}>
         <BasicButton
@@ -63,7 +69,7 @@ export default function ConfirmModal({
           width='calc(50% - 12px)'
           onClick={handleConfirm}
           height='30px'
-          disabled={disabled}
+          disabled={disabled || confirmDisabled}
         >
           {confirmText}
         </BasicButton>

--- a/frontend/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal/ConfirmModal.tsx
@@ -20,7 +20,6 @@ export interface ConfirmModalProps {
   width?: number;
   height?: number;
   disabled?: boolean;
-  confirmDisabled?: boolean;
   children?: React.ReactNode;
 }
 
@@ -34,7 +33,6 @@ export default function ConfirmModal({
   width = 300,
   height,
   disabled = false,
-  confirmDisabled = false,
   children,
 }: ConfirmModalProps) {
   const theme = useAppTheme();
@@ -69,7 +67,7 @@ export default function ConfirmModal({
           width='calc(50% - 12px)'
           onClick={handleConfirm}
           height='30px'
-          disabled={disabled || confirmDisabled}
+          disabled={disabled}
         >
           {confirmText}
         </BasicButton>

--- a/frontend/src/components/icons/OutOutlineIcon.tsx
+++ b/frontend/src/components/icons/OutOutlineIcon.tsx
@@ -9,21 +9,21 @@ export default function OutOutlineIcon() {
     >
       <path
         d='M9.3335 9.91683L12.2502 7.00016L9.3335 4.0835'
-        stroke='#E7000B'
+        stroke='#4A5565'
         strokeWidth='1.16667'
         strokeLinecap='round'
         strokeLinejoin='round'
       />
       <path
         d='M12.25 7H5.25'
-        stroke='#E7000B'
+        stroke='#4A5565'
         strokeWidth='1.16667'
         strokeLinecap='round'
         strokeLinejoin='round'
       />
       <path
         d='M5.25 12.25H2.91667C2.60725 12.25 2.3105 12.1271 2.09171 11.9083C1.87292 11.6895 1.75 11.3928 1.75 11.0833V2.91667C1.75 2.60725 1.87292 2.3105 2.09171 2.09171C2.3105 1.87292 2.60725 1.75 2.91667 1.75H5.25'
-        stroke='#E7000B'
+        stroke='#4A5565'
         strokeWidth='1.16667'
         strokeLinecap='round'
         strokeLinejoin='round'

--- a/frontend/src/domains/admin/Settings/Settings.style.ts
+++ b/frontend/src/domains/admin/Settings/Settings.style.ts
@@ -1,51 +1,9 @@
 import { css } from '@emotion/react';
-import { Theme } from '@/theme';
 
 export const settingsContainer = css`
   display: flex;
   flex-direction: column;
   gap: 20px;
-`;
-
-export const withdrawModalContent = css`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: 100%;
-  align-items: flex-start;
-`;
-
-export const withdrawWarningText = (theme: Theme) => css`
-  ${theme.typography.pretendard.captionSmall}
-
-  color: ${theme.colors.gray[600]};
-  line-height: 1.5;
-`;
-
-export const withdrawDeletedItemsList = (theme: Theme) => css`
-  margin: 0;
-  padding-left: 20px;
-  list-style-type: disc;
-  ${theme.typography.pretendard.captionSmall}
-
-  color: ${theme.colors.gray[600]};
-  line-height: 1.8;
-`;
-
-export const withdrawAgreementLabel = (theme: Theme) => css`
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  ${theme.typography.pretendard.captionSmall}
-
-  color: ${theme.colors.black[100]};
-  cursor: pointer;
-  line-height: 1.5;
-`;
-
-export const withdrawCheckbox = css`
-  margin-top: 2px;
-  cursor: pointer;
 `;
 
 export const withdrawSettingListBox = css`

--- a/frontend/src/domains/admin/Settings/Settings.style.ts
+++ b/frontend/src/domains/admin/Settings/Settings.style.ts
@@ -1,7 +1,49 @@
 import { css } from '@emotion/react';
+import { Theme } from '@/theme';
 
 export const settingsContainer = css`
   display: flex;
   flex-direction: column;
   gap: 20px;
+`;
+
+export const withdrawModalContent = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  align-items: flex-start;
+`;
+
+export const withdrawWarningText = (theme: Theme) => css`
+  ${theme.typography.pretendard.captionSmall}
+
+  color: ${theme.colors.gray[600]};
+  line-height: 1.5;
+`;
+
+export const withdrawDeletedItemsList = (theme: Theme) => css`
+  margin: 0;
+  padding-left: 20px;
+  list-style-type: disc;
+  ${theme.typography.pretendard.captionSmall}
+
+  color: ${theme.colors.gray[600]};
+  line-height: 1.8;
+`;
+
+export const withdrawAgreementLabel = (theme: Theme) => css`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  ${theme.typography.pretendard.captionSmall}
+
+  color: ${theme.colors.black[100]};
+  cursor: pointer;
+  line-height: 1.5;
+`;
+
+export const withdrawCheckbox = css`
+  margin-top: 2px;
+  cursor: pointer;
 `;

--- a/frontend/src/domains/admin/Settings/Settings.style.ts
+++ b/frontend/src/domains/admin/Settings/Settings.style.ts
@@ -47,3 +47,7 @@ export const withdrawCheckbox = css`
   margin-top: 2px;
   cursor: pointer;
 `;
+
+export const withdrawSettingListBox = css`
+  margin-top: 30px;
+`;

--- a/frontend/src/domains/admin/Settings/Settings.tsx
+++ b/frontend/src/domains/admin/Settings/Settings.tsx
@@ -5,24 +5,14 @@ import BellOutlineIcon from '@/components/icons/BellOutlineIcon';
 import OutOutlineIcon from '@/components/icons/OutOutlineIcon';
 import SendIcon from '@/components/icons/SendIcon';
 import TrashCanIcon from '@/components/icons/TrashCanIcon';
-import ConfirmModal from '@/components/ConfirmModal/ConfirmModal';
 import ProfileBox from './components/ProfileBox/ProfileBox';
 import SettingListBox from './components/SettingListBox/SettingListBox';
-import { useLogout } from './hooks/useLogout';
-import { useWithdraw } from './hooks/useWithdraw';
+import WithdrawModal from './components/WithdrawModal/WithdrawModal';
+import LogoutModal from './components/LogoutModal/LogoutModal';
 import { useNotificationSettingsPage } from './hooks/useNotificationSettingsPage';
-import {
-  settingsContainer,
-  withdrawModalContent,
-  withdrawWarningText,
-  withdrawDeletedItemsList,
-  withdrawAgreementLabel,
-  withdrawCheckbox,
-  withdrawSettingListBox,
-} from './Settings.style';
+import { settingsContainer, withdrawSettingListBox } from './Settings.style';
 import useAdminAuth from '@/domains/admin/Settings/hooks/useAdminAuth';
 import { usePWAPrompt } from '@/contexts/usePWAPrompt';
-import { useAppTheme } from '@/hooks/useAppTheme';
 
 declare global {
   interface Window {
@@ -37,8 +27,6 @@ type ModalState = { type: 'logout' } | { type: 'withdraw' } | { type: null };
 
 export default function Settings() {
   const [modalState, setModalState] = useState<ModalState>({ type: null });
-  const [isWithdrawChecked, setIsWithdrawChecked] = useState(false);
-  const theme = useAppTheme();
   const {
     isToggleEnabled,
     updateNotificationSetting,
@@ -47,13 +35,10 @@ export default function Settings() {
     needsPWAInstall,
   } = useNotificationSettingsPage();
   const { adminAuth, isLoading: isAdminAuthLoading } = useAdminAuth();
-  const { handleLogout } = useLogout();
-  const { handleWithdraw } = useWithdraw();
   const { showPrompt } = usePWAPrompt();
 
   const closeModal = () => {
     setModalState({ type: null });
-    setIsWithdrawChecked(false);
   };
 
   const handleToggleClick = () => {
@@ -132,42 +117,10 @@ export default function Settings() {
           />
         </div>
 
-        {modalState.type === 'logout' && (
-          <ConfirmModal
-            title='로그아웃'
-            message='정말 로그아웃하시겠습니까?'
-            onConfirm={handleLogout}
-            onClose={closeModal}
-          />
-        )}
+        {modalState.type === 'logout' && <LogoutModal onClose={closeModal} />}
 
         {modalState.type === 'withdraw' && (
-          <ConfirmModal
-            title='회원탈퇴'
-            onConfirm={handleWithdraw}
-            onClose={closeModal}
-            confirmText='탈퇴하기'
-            disabled={!isWithdrawChecked}
-          >
-            <div css={withdrawModalContent}>
-              <p css={withdrawWarningText(theme)}>
-                탈퇴 시 정보가 삭제되며 복구 불가합니다.
-              </p>
-              <ul css={withdrawDeletedItemsList(theme)}>
-                <li>관리자 계정 및 로그인 정보</li>
-                <li>서비스 내 모든 정보</li>
-              </ul>
-              <label css={withdrawAgreementLabel(theme)}>
-                <input
-                  type='checkbox'
-                  checked={isWithdrawChecked}
-                  onChange={(e) => setIsWithdrawChecked(e.target.checked)}
-                  css={withdrawCheckbox}
-                />
-                <span>위 내용을 모두 확인했고, 탈퇴하는 것에 동의합니다.</span>
-              </label>
-            </div>
-          </ConfirmModal>
+          <WithdrawModal onClose={closeModal} />
         )}
       </div>
     </>

--- a/frontend/src/domains/admin/Settings/Settings.tsx
+++ b/frontend/src/domains/admin/Settings/Settings.tsx
@@ -4,14 +4,23 @@ import BasicToggleButton from '@/components/BasicToggleButton/BasicToggleButton'
 import BellOutlineIcon from '@/components/icons/BellOutlineIcon';
 import OutOutlineIcon from '@/components/icons/OutOutlineIcon';
 import SendIcon from '@/components/icons/SendIcon';
+import TrashCanIcon from '@/components/icons/TrashCanIcon';
 import ConfirmModal from '@/components/ConfirmModal/ConfirmModal';
 import ProfileBox from './components/ProfileBox/ProfileBox';
 import SettingListBox from './components/SettingListBox/SettingListBox';
 import { useLogout } from './hooks/useLogout';
 import { useNotificationSettingsPage } from './hooks/useNotificationSettingsPage';
-import { settingsContainer } from './Settings.style';
+import {
+  settingsContainer,
+  withdrawModalContent,
+  withdrawWarningText,
+  withdrawDeletedItemsList,
+  withdrawAgreementLabel,
+  withdrawCheckbox,
+} from './Settings.style';
 import useAdminAuth from '@/domains/admin/Settings/hooks/useAdminAuth';
 import { usePWAPrompt } from '@/contexts/usePWAPrompt';
+import { useAppTheme } from '@/hooks/useAppTheme';
 
 declare global {
   interface Window {
@@ -22,10 +31,12 @@ declare global {
   }
 }
 
-type ModalState = { type: 'logout' } | { type: null };
+type ModalState = { type: 'logout' } | { type: 'withdraw' } | { type: null };
 
 export default function Settings() {
   const [modalState, setModalState] = useState<ModalState>({ type: null });
+  const [isWithdrawChecked, setIsWithdrawChecked] = useState(false);
+  const theme = useAppTheme();
   const {
     isToggleEnabled,
     updateNotificationSetting,
@@ -39,6 +50,7 @@ export default function Settings() {
 
   const closeModal = () => {
     setModalState({ type: null });
+    setIsWithdrawChecked(false);
   };
 
   const handleToggleClick = () => {
@@ -62,6 +74,11 @@ export default function Settings() {
       return '알림을 받기위해 홈 화면에 앱을 추가해주세요. 터치하면 설치 화면이 나옵니다.';
     }
     return '푸시 알림 받기 설정';
+  };
+
+  const handleWithdraw = () => {
+    // TODO: 회원탈퇴 API 연결
+    console.log('회원탈퇴');
   };
 
   return (
@@ -109,6 +126,13 @@ export default function Settings() {
           onClick={() => setModalState({ type: 'logout' })}
         />
 
+        <SettingListBox
+          icon={<TrashCanIcon />}
+          title='회원탈퇴'
+          variant='danger'
+          onClick={() => setModalState({ type: 'withdraw' })}
+        />
+
         {modalState.type === 'logout' && (
           <ConfirmModal
             title='로그아웃'
@@ -116,6 +140,35 @@ export default function Settings() {
             onConfirm={handleLogout}
             onClose={closeModal}
           />
+        )}
+
+        {modalState.type === 'withdraw' && (
+          <ConfirmModal
+            title='회원탈퇴'
+            onConfirm={handleWithdraw}
+            onClose={closeModal}
+            confirmText='탈퇴하기'
+            confirmDisabled={!isWithdrawChecked}
+          >
+            <div css={withdrawModalContent}>
+              <p css={withdrawWarningText(theme)}>
+                탈퇴 시 정보가 삭제되며 복구 불가합니다.
+              </p>
+              <ul css={withdrawDeletedItemsList(theme)}>
+                <li>관리자 계정 및 로그인 정보</li>
+                <li>서비스 내 모든 정보</li>
+              </ul>
+              <label css={withdrawAgreementLabel(theme)}>
+                <input
+                  type='checkbox'
+                  checked={isWithdrawChecked}
+                  onChange={(e) => setIsWithdrawChecked(e.target.checked)}
+                  css={withdrawCheckbox}
+                />
+                <span>위 내용을 모두 확인했고, 탈퇴하는 것에 동의합니다.</span>
+              </label>
+            </div>
+          </ConfirmModal>
         )}
       </div>
     </>

--- a/frontend/src/domains/admin/Settings/Settings.tsx
+++ b/frontend/src/domains/admin/Settings/Settings.tsx
@@ -147,7 +147,7 @@ export default function Settings() {
             onConfirm={handleWithdraw}
             onClose={closeModal}
             confirmText='탈퇴하기'
-            confirmDisabled={!isWithdrawChecked}
+            disabled={!isWithdrawChecked}
           >
             <div css={withdrawModalContent}>
               <p css={withdrawWarningText(theme)}>

--- a/frontend/src/domains/admin/Settings/Settings.tsx
+++ b/frontend/src/domains/admin/Settings/Settings.tsx
@@ -9,6 +9,7 @@ import ConfirmModal from '@/components/ConfirmModal/ConfirmModal';
 import ProfileBox from './components/ProfileBox/ProfileBox';
 import SettingListBox from './components/SettingListBox/SettingListBox';
 import { useLogout } from './hooks/useLogout';
+import { useWithdraw } from './hooks/useWithdraw';
 import { useNotificationSettingsPage } from './hooks/useNotificationSettingsPage';
 import {
   settingsContainer,
@@ -17,6 +18,7 @@ import {
   withdrawDeletedItemsList,
   withdrawAgreementLabel,
   withdrawCheckbox,
+  withdrawSettingListBox,
 } from './Settings.style';
 import useAdminAuth from '@/domains/admin/Settings/hooks/useAdminAuth';
 import { usePWAPrompt } from '@/contexts/usePWAPrompt';
@@ -46,6 +48,7 @@ export default function Settings() {
   } = useNotificationSettingsPage();
   const { adminAuth, isLoading: isAdminAuthLoading } = useAdminAuth();
   const { handleLogout } = useLogout();
+  const { handleWithdraw } = useWithdraw();
   const { showPrompt } = usePWAPrompt();
 
   const closeModal = () => {
@@ -74,11 +77,6 @@ export default function Settings() {
       return '알림을 받기위해 홈 화면에 앱을 추가해주세요. 터치하면 설치 화면이 나옵니다.';
     }
     return '푸시 알림 받기 설정';
-  };
-
-  const handleWithdraw = () => {
-    // TODO: 회원탈퇴 API 연결
-    console.log('회원탈퇴');
   };
 
   return (
@@ -122,16 +120,17 @@ export default function Settings() {
         <SettingListBox
           icon={<OutOutlineIcon />}
           title='로그아웃'
-          variant='danger'
           onClick={() => setModalState({ type: 'logout' })}
         />
 
-        <SettingListBox
-          icon={<TrashCanIcon />}
-          title='회원탈퇴'
-          variant='danger'
-          onClick={() => setModalState({ type: 'withdraw' })}
-        />
+        <div css={withdrawSettingListBox}>
+          <SettingListBox
+            icon={<TrashCanIcon />}
+            title='회원탈퇴'
+            variant='danger'
+            onClick={() => setModalState({ type: 'withdraw' })}
+          />
+        </div>
 
         {modalState.type === 'logout' && (
           <ConfirmModal

--- a/frontend/src/domains/admin/Settings/components/LogoutModal/LogoutModal.tsx
+++ b/frontend/src/domains/admin/Settings/components/LogoutModal/LogoutModal.tsx
@@ -1,0 +1,19 @@
+import ConfirmModal from '@/components/ConfirmModal/ConfirmModal';
+import { useLogout } from '../../hooks/useLogout';
+
+interface LogoutModalProps {
+  onClose: () => void;
+}
+
+export default function LogoutModal({ onClose }: LogoutModalProps) {
+  const { handleLogout } = useLogout();
+
+  return (
+    <ConfirmModal
+      title='로그아웃'
+      message='정말 로그아웃하시겠습니까?'
+      onConfirm={handleLogout}
+      onClose={onClose}
+    />
+  );
+}

--- a/frontend/src/domains/admin/Settings/components/WithdrawModal/WithdrawModal.style.ts
+++ b/frontend/src/domains/admin/Settings/components/WithdrawModal/WithdrawModal.style.ts
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+import { Theme } from '@/theme';
+
+export const withdrawModalContent = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  align-items: flex-start;
+`;
+
+export const withdrawWarningText = (theme: Theme) => css`
+  ${theme.typography.pretendard.captionSmall}
+
+  color: ${theme.colors.gray[600]};
+  line-height: 1.5;
+`;
+
+export const withdrawDeletedItemsList = (theme: Theme) => css`
+  margin: 0;
+  padding-left: 20px;
+  list-style-type: disc;
+  ${theme.typography.pretendard.captionSmall}
+
+  color: ${theme.colors.gray[600]};
+  line-height: 1.8;
+`;
+
+export const withdrawAgreementLabel = (theme: Theme) => css`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  ${theme.typography.pretendard.captionSmall}
+
+  color: ${theme.colors.black[100]};
+  cursor: pointer;
+  line-height: 1.5;
+`;
+
+export const withdrawCheckbox = css`
+  margin-top: 2px;
+  cursor: pointer;
+`;

--- a/frontend/src/domains/admin/Settings/components/WithdrawModal/WithdrawModal.tsx
+++ b/frontend/src/domains/admin/Settings/components/WithdrawModal/WithdrawModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import ConfirmModal from '@/components/ConfirmModal/ConfirmModal';
+import { useWithdraw } from '../../hooks/useWithdraw';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import {
+  withdrawModalContent,
+  withdrawWarningText,
+  withdrawDeletedItemsList,
+  withdrawAgreementLabel,
+  withdrawCheckbox,
+} from './WithdrawModal.style';
+
+interface WithdrawModalProps {
+  onClose: () => void;
+}
+
+export default function WithdrawModal({ onClose }: WithdrawModalProps) {
+  const [isWithdrawChecked, setIsWithdrawChecked] = useState(false);
+  const theme = useAppTheme();
+  const { handleWithdraw } = useWithdraw();
+
+  const handleClose = () => {
+    setIsWithdrawChecked(false);
+    onClose();
+  };
+
+  return (
+    <ConfirmModal
+      title='회원탈퇴'
+      onConfirm={handleWithdraw}
+      onClose={handleClose}
+      confirmText='탈퇴하기'
+      disabled={!isWithdrawChecked}
+    >
+      <div css={withdrawModalContent}>
+        <p css={withdrawWarningText(theme)}>
+          탈퇴 시 정보가 삭제되며 복구 불가합니다.
+        </p>
+        <ul css={withdrawDeletedItemsList(theme)}>
+          <li>관리자 계정 및 로그인 정보</li>
+          <li>서비스 내 모든 정보</li>
+        </ul>
+        <label css={withdrawAgreementLabel(theme)}>
+          <input
+            type='checkbox'
+            checked={isWithdrawChecked}
+            onChange={(e) => setIsWithdrawChecked(e.target.checked)}
+            css={withdrawCheckbox}
+          />
+          <span>위 내용을 모두 확인했고, 탈퇴하는 것에 동의합니다.</span>
+        </label>
+      </div>
+    </ConfirmModal>
+  );
+}

--- a/frontend/src/domains/admin/Settings/hooks/useWithdraw.ts
+++ b/frontend/src/domains/admin/Settings/hooks/useWithdraw.ts
@@ -3,18 +3,21 @@ import useNavigation from '@/domains/hooks/useNavigation';
 import { NotificationService } from '@/services/notificationService';
 import { resetLocalStorage } from '@/utils/localStorage';
 import { useMutation } from '@tanstack/react-query';
+import { useToast } from '@/contexts/useToast';
 
 export function useWithdraw() {
   const { goPath } = useNavigation();
+  const { showToast } = useToast();
 
   const { mutateAsync: handleWithdraw } = useMutation({
     mutationFn: deleteAdmin,
     onSuccess: () => {
       resetLocalStorage('auth');
+      NotificationService.removeToken();
       goPath('/');
     },
-    onSettled: () => {
-      NotificationService.removeToken();
+    onError: () => {
+      showToast('탈퇴 처리 중 문제가 발생했어요. 잠시 후 다시 시도해주세요');
     },
   });
 

--- a/frontend/src/domains/admin/Settings/hooks/useWithdraw.ts
+++ b/frontend/src/domains/admin/Settings/hooks/useWithdraw.ts
@@ -1,0 +1,24 @@
+import { deleteAdmin } from '@/apis/admin.api';
+import useNavigation from '@/domains/hooks/useNavigation';
+import { NotificationService } from '@/services/notificationService';
+import { resetLocalStorage } from '@/utils/localStorage';
+import { useMutation } from '@tanstack/react-query';
+
+export function useWithdraw() {
+  const { goPath } = useNavigation();
+
+  const { mutateAsync: handleWithdraw } = useMutation({
+    mutationFn: deleteAdmin,
+    onSuccess: () => {
+      resetLocalStorage('auth');
+      goPath('/');
+    },
+    onSettled: () => {
+      NotificationService.removeToken();
+    },
+  });
+
+  return {
+    handleWithdraw,
+  };
+}

--- a/frontend/src/domains/admin/Settings/hooks/useWithdraw.ts
+++ b/frontend/src/domains/admin/Settings/hooks/useWithdraw.ts
@@ -3,11 +3,9 @@ import useNavigation from '@/domains/hooks/useNavigation';
 import { NotificationService } from '@/services/notificationService';
 import { resetLocalStorage } from '@/utils/localStorage';
 import { useMutation } from '@tanstack/react-query';
-import { useToast } from '@/contexts/useToast';
 
 export function useWithdraw() {
   const { goPath } = useNavigation();
-  const { showToast } = useToast();
 
   const { mutateAsync: handleWithdraw } = useMutation({
     mutationFn: deleteAdmin,
@@ -15,9 +13,6 @@ export function useWithdraw() {
       resetLocalStorage('auth');
       NotificationService.removeToken();
       goPath('/');
-    },
-    onError: () => {
-      showToast('탈퇴 처리 중 문제가 발생했어요. 잠시 후 다시 시도해주세요');
     },
   });
 


### PR DESCRIPTION
## 😉 연관 이슈
#1003 

## 🚀 작업 내용
- 회원탈퇴 UI, API연동 구현했슴당

https://github.com/user-attachments/assets/fa68a028-e54d-4061-af5d-214311342e0c



- 아래 영상은 제대로 회원탈퇴가 됐는지, 회원탈퇴한 계정으로 로그인 안되는지 확인한 영상입니다.
- 회원탈퇴한 계정으로 회원가입하면 오류가 나는데, 이건 백엔드에서 soft delete해서 생긴 문제고 오류 메세지 수정해준다고 하십니다!



https://github.com/user-attachments/assets/eaf7f416-3266-4d0d-8d8e-575f2b0cdfc1

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 계정 탈퇴 기능 추가 — 삭제될 항목 목록 확인 후 동의 체크박스로 탈퇴 진행 가능하며, 탈퇴 시 자동 로그아웃 및 홈으로 이동합니다.
  * 로그아웃과 탈퇴가 각각의 확인 모달로 분리되어 별도 흐름으로 동작합니다.
  * 확인 모달에 맞춤 콘텐츠(children) 삽입 지원 추가.
  * 탈퇴 처리 실패 시 안내 토스트 표시.

* **스타일**
  * 일부 아이콘 색상을 빨간색에서 회색으로 변경.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->