### PR TITLE
[BE] feat: 비동기 실패 작업 유실 최소화 작업

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -82,6 +82,10 @@ dependencies {
 
     //profanity filter
     implementation 'io.github.vaneproject:vane-badwordfiltering:1.0.0'
+
+    //retry and rate limiting
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 }
 
 tasks.register('copySecret', Copy) {

--- a/backend/src/main/java/feedzupzup/backend/develop/service/DeveloperService.java
+++ b/backend/src/main/java/feedzupzup/backend/develop/service/DeveloperService.java
@@ -61,8 +61,8 @@ public class DeveloperService {
             }
 
             try {
-                FeedbackEmbeddingCluster cluster = feedbackClusteringService.cluster(feedback.getId());
-                feedbackClusteringService.createLabel(cluster.getId());
+                Long clusterId = feedbackClusteringService.cluster(feedback.getId());
+                feedbackClusteringService.createLabel(clusterId);
                 processedCount++;
             } catch (Exception e) {
                 log.error("피드백 ID {} 클러스터링 실패: {}", feedback.getId(), e.getMessage());

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackClusteringService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/FeedbackClusteringService.java
@@ -34,7 +34,7 @@ public class FeedbackClusteringService {
 
     // TODO : embedding 트랜잭션애 포함되어 커넥션 잡아먹음. 추후 수정 필요
     @Transactional
-    public FeedbackEmbeddingCluster cluster(final Long createdFeedbackId) {
+    public Long cluster(final Long createdFeedbackId) {
         final Feedback createdFeedback = getFeedback(createdFeedbackId);
         if (feedbackEmbeddingClusterRepository.existsByFeedback(createdFeedback)) {
             throw new AlreadyClusteringException("이미 클러스터링 된 피드백입니다. (feedabckId = " + createdFeedbackId + ")");
@@ -48,10 +48,10 @@ public class FeedbackClusteringService {
             embeddingClusterRepository.save(empty);
             final FeedbackEmbeddingCluster newCluster = FeedbackEmbeddingCluster.createNewCluster(createdFeedbackEmbedding,
                     createdFeedback, empty);
-            return feedbackEmbeddingClusterRepository.save(newCluster);
+            return feedbackEmbeddingClusterRepository.save(newCluster).getId();
         }
 
-        return feedbackEmbeddingClusterRepository.save(assignedCluster.get());
+        return feedbackEmbeddingClusterRepository.save(assignedCluster.get()).getId();
     }
 
     private Optional<FeedbackEmbeddingCluster> assignCluster(final Feedback createdFeedback, final double[] createdFeedbackEmbedding) {

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/event/FeedbackClusteringHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/event/FeedbackClusteringHandler.java
@@ -1,24 +1,55 @@
 package feedzupzup.backend.feedback.application.event;
 
+import static feedzupzup.backend.global.async.TargetType.*;
+import static feedzupzup.backend.global.async.TaskType.*;
+
 import feedzupzup.backend.feedback.application.FeedbackClusteringService;
-import feedzupzup.backend.feedback.domain.FeedbackEmbeddingCluster;
 import feedzupzup.backend.feedback.domain.event.FeedbackCreatedEvent2;
+import feedzupzup.backend.global.async.AsyncTaskFailureService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FeedbackClusteringHandler {
 
     private final FeedbackClusteringService feedbackClusteringService;
+    private final AsyncTaskFailureService asyncTaskFailureService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async
+    @Async("externalApiExecutor")
     public void handleFeedbackCreatedEvent(final FeedbackCreatedEvent2 event) {
-        FeedbackEmbeddingCluster createdCluster = feedbackClusteringService.cluster(event.feedbackId());
-        feedbackClusteringService.createLabel(createdCluster.getId());
+        cluster(event.feedbackId())
+                .ifPresent(this::createLabel);
+    }
+
+    private Optional<Long> cluster(final Long feedbackId) {
+        try {
+            return Optional.of(feedbackClusteringService.cluster(feedbackId));
+        } catch (Exception ex) {
+            log.error("피드백 클러스터링 작업 최종 실패: 피드백ID={}", feedbackId, ex);
+            Long failureId = asyncTaskFailureService.recordFailure(FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, feedbackId.toString(), ex);
+            asyncTaskFailureService.alertFinalFail(failureId);
+            return Optional.empty();
+        }
+    }
+
+    private void createLabel(final Long createdFeedbackClusterId) {
+        if (createdFeedbackClusterId == null) {
+            return;
+        }
+        try {
+            feedbackClusteringService.createLabel(createdFeedbackClusterId);
+        } catch (Exception ex) {
+            log.error("피드백 클러스터링 라벨 생성 작업 최종 실패: 피드백 클러스터 ID={}", createdFeedbackClusterId, ex);
+            Long failureId = asyncTaskFailureService.recordFailure(CLUSTER_LABEL_GENERATION, FEEDBACK, createdFeedbackClusterId.toString(), ex);
+            asyncTaskFailureService.alertFinalFail(failureId);
+        }
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIEmbeddingClient.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIEmbeddingClient.java
@@ -58,7 +58,7 @@ public class VoyageAIEmbeddingClient {
                 .map(VoyageAIEmbeddingResponse::getData)
                 .filter(data -> !data.isEmpty())
                 .map(data -> data.getFirst().getEmbedding())
-                .orElseThrow(() -> new NonRetryableException("임베딩 데이터가 비어 있거나 응답이 없습니다"));
+                .orElseThrow(() -> new RetryableException("임베딩 데이터가 비어 있거나 응답이 없습니다"));
     }
 
     private String summarizeInput(String text) {

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIEmbeddingClient.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIEmbeddingClient.java
@@ -1,53 +1,56 @@
 package feedzupzup.backend.feedback.infrastructure.embedding;
 
-import feedzupzup.backend.global.exception.InfrastructureException.RestClientServerException;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
 public class VoyageAIEmbeddingClient {
 
     private final VoyageAIProperties voyageAIProperties;
     private final RestClient voyageAiEmbeddingRestClient;
     private final VoyageAIErrorHandler voyageAIErrorHandler;
 
+    @Retryable(
+            retryFor = {RetryableException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 200, multiplier = 2)
+    )
     public double[] extractEmbedding(final String text) {
-        try {
-            Map<String, Object> requestBody = Map.of(
-                    "input", text,
-                    "model", voyageAIProperties.getEmbeddingModel(),
-                    "input_type", "document"
-            );
-            log.info("[VoyageAI] 임베딩 요청 시작 - model: {}, input: {}",
-                    voyageAIProperties.getEmbeddingModel(),
-                    summarizeInput(text));
+        Map<String, Object> requestBody = Map.of(
+                "input", text,
+                "model", voyageAIProperties.getEmbeddingModel(),
+                "input_type", "document"
+        );
+        log.info("[VoyageAI] 임베딩 요청 시작 - model: {}, input: {}",
+                voyageAIProperties.getEmbeddingModel(),
+                summarizeInput(text));
 
-            VoyageAIEmbeddingResponse response = voyageAiEmbeddingRestClient.post()
-                    .body(requestBody)
-                    .retrieve()
-                    .onStatus(HttpStatusCode::isError, voyageAIErrorHandler::handleError)
-                    .body(VoyageAIEmbeddingResponse.class);
+        VoyageAIEmbeddingResponse response = voyageAiEmbeddingRestClient.post()
+                .body(requestBody)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, voyageAIErrorHandler::handleError)
+                .body(VoyageAIEmbeddingResponse.class);
 
-            double[] embedding = extractEmbeddingOrThrow(response);
+        double[] embedding = extractEmbeddingOrThrow(response);
 
-            log.info("[VoyageAI] 임베딩 요청 성공 - inputLength: {}, embeddingLength: {}, totalTokens: {}",
-                    text.length(),
-                    embedding.length,
-                    response.getUsage().getTotalTokens()
-            );
+        log.info("[VoyageAI] 임베딩 요청 성공 - inputLength: {}, embeddingLength: {}, totalTokens: {}",
+                text.length(),
+                embedding.length,
+                response.getUsage().getTotalTokens()
+        );
 
-            return embedding;
-        } catch (Exception e) {
-            log.error("임베딩 생성 실패: {}", e.getMessage(), e);
-            throw new RestClientServerException("임베딩 생성 중 오류 발생: " + e.getMessage(), e);
-        }
+        return embedding;
     }
 
     private double[] extractEmbeddingOrThrow(final VoyageAIEmbeddingResponse response) {
@@ -55,13 +58,17 @@ public class VoyageAIEmbeddingClient {
                 .map(VoyageAIEmbeddingResponse::getData)
                 .filter(data -> !data.isEmpty())
                 .map(data -> data.getFirst().getEmbedding())
-                .orElseThrow(() -> new RestClientServerException("임베딩 데이터가 비어 있거나 응답이 없습니다"));
+                .orElseThrow(() -> new NonRetryableException("임베딩 데이터가 비어 있거나 응답이 없습니다"));
     }
 
     private String summarizeInput(String text) {
         int maxLen = 50;
-        if (text == null) return "null";
-        if (text.length() <= maxLen) return text;
+        if (text == null) {
+            return "null";
+        }
+        if (text.length() <= maxLen) {
+            return text;
+        }
         return text.substring(0, maxLen) + "...(" + text.length() + " chars)";
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIErrorHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIErrorHandler.java
@@ -1,13 +1,14 @@
 package feedzupzup.backend.feedback.infrastructure.embedding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import feedzupzup.backend.global.exception.InfrastructureException.RestClientServerException;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 
@@ -19,14 +20,31 @@ public class VoyageAIErrorHandler {
     private final ObjectMapper objectMapper;
 
     public void handleError(final HttpRequest request, final ClientHttpResponse response) {
-        try (InputStream bodyStream = response.getBody()) {
-            final VoyageAIErrorResponse errorResponse = objectMapper.readValue(bodyStream, VoyageAIErrorResponse.class);
+        try {
+            final HttpStatus httpStatus = HttpStatus.valueOf(response.getStatusCode().value());
+            try (InputStream bodyStream = response.getBody()) {
+                final VoyageAIErrorResponse errorResponse = objectMapper.readValue(bodyStream, VoyageAIErrorResponse.class);
+                log.warn("VoyageAI API 오류 [{}] : {}", httpStatus, errorResponse.getDetail());
 
-            log.error("VoyageAI API 실패 내용 : {}", errorResponse.getDetail());
-            throw new RestClientServerException("VoyageAI API를 실패하였습니다. request URI : " + request.getURI());
+                if (isRetryableError(httpStatus)) {
+                    throw new RetryableException(String.format("VoyageAI API 일시적 오류 [%s]: %s",
+                            httpStatus, errorResponse.getDetail()));
+                }
+                throw new NonRetryableException(String.format("VoyageAI API 오류 [%s]: %s",
+                        httpStatus, errorResponse.getDetail()));
+            }
         } catch (IOException e) {
             log.error("VoyageAI Error Parsing Failed: {}", e.getMessage());
-            throw new RestClientServerException("VoyageAI 에러 응답 파싱 실패", e);
+            throw new RetryableException("VoyageAI 에러 응답 파싱 실패", e);
         }
+    }
+
+    private boolean isRetryableError(final HttpStatus httpStatus) {
+        return httpStatus == HttpStatus.TOO_MANY_REQUESTS ||
+                httpStatus == HttpStatus.REQUEST_TIMEOUT ||
+                httpStatus == HttpStatus.SERVICE_UNAVAILABLE ||
+                httpStatus == HttpStatus.BAD_GATEWAY ||
+                httpStatus == HttpStatus.GATEWAY_TIMEOUT ||
+                httpStatus.is5xxServerError();
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/llm/OpenAICompletionClient.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/llm/OpenAICompletionClient.java
@@ -63,6 +63,6 @@ public class OpenAICompletionClient {
                 .filter(choices -> !choices.isEmpty())
                 .map(choices -> choices.getFirst().getMessage().getContent())
                 .filter(content -> !content.trim().isEmpty())
-                .orElseThrow(() -> new NonRetryableException("생성된 텍스트가 비어 있거나 응답이 없습니다"));
+                .orElseThrow(() -> new RetryableException("생성된 텍스트가 비어 있거나 응답이 없습니다"));
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/llm/OpenAICompletionClient.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/llm/OpenAICompletionClient.java
@@ -1,57 +1,60 @@
 package feedzupzup.backend.feedback.infrastructure.llm;
 
-import feedzupzup.backend.global.exception.InfrastructureException.RestClientServerException;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
 public class OpenAICompletionClient {
 
     private final OpenAIProperties openAIProperties;
     private final RestClient openAiCompletionRestClient;
     private final OpenAIErrorHandler openAIErrorHandler;
 
+    @Retryable(
+            retryFor = {RetryableException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 200, multiplier = 2)
+    )
     public String generateCompletion(final String prompt, final String systemMessage) {
-        try {
-            final Map<String, Object> requestBody = Map.of(
-                    "model", openAIProperties.getCompletionModel(),
-                    "messages", List.of(
-                            Map.of("role", "system", "content", systemMessage),
-                            Map.of("role", "user", "content", prompt)
-                    ),
-                    "max_tokens", openAIProperties.getMaxTokens(),
-                    "temperature", openAIProperties.getTemperature()
-            );
+        final Map<String, Object> requestBody = Map.of(
+                "model", openAIProperties.getCompletionModel(),
+                "messages", List.of(
+                        Map.of("role", "system", "content", systemMessage),
+                        Map.of("role", "user", "content", prompt)
+                ),
+                "max_tokens", openAIProperties.getMaxTokens(),
+                "temperature", openAIProperties.getTemperature()
+        );
 
-            log.info("[OpenAI] 텍스트 생성 요청 시작 - model: {}, promptLength: {}",
-                    openAIProperties.getCompletionModel(),
-                    prompt.length());
+        log.info("[OpenAI] 텍스트 생성 요청 시작 - model: {}, promptLength: {}",
+                openAIProperties.getCompletionModel(),
+                prompt.length());
 
-            final OpenAICompletionResponse response = openAiCompletionRestClient.post()
-                    .body(requestBody)
-                    .retrieve()
-                    .onStatus(HttpStatusCode::isError, openAIErrorHandler::handleError)
-                    .body(OpenAICompletionResponse.class);
+        final OpenAICompletionResponse response = openAiCompletionRestClient.post()
+                .body(requestBody)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, openAIErrorHandler::handleError)
+                .body(OpenAICompletionResponse.class);
 
-            final String completion = extractCompletionOrThrow(response);
+        final String completion = extractCompletionOrThrow(response);
 
-            log.info("[OpenAI] 텍스트 생성 성공 - completionLength: {}, totalTokens: {}",
-                    completion.length(),
-                    response.getUsage().getTotalTokens());
+        log.info("[OpenAI] 텍스트 생성 성공 - completionLength: {}, totalTokens: {}",
+                completion.length(),
+                response.getUsage().getTotalTokens());
 
-            return completion;
-        } catch (Exception e) {
-            log.error("피드백 라벨 생성 실패: {}", e.getMessage(), e);
-            throw new RestClientServerException("피드백 라벨 생성 중 오류 발생: " + e.getMessage(), e);
-        }
+        return completion;
     }
 
     private String extractCompletionOrThrow(final OpenAICompletionResponse response) {
@@ -60,6 +63,6 @@ public class OpenAICompletionClient {
                 .filter(choices -> !choices.isEmpty())
                 .map(choices -> choices.getFirst().getMessage().getContent())
                 .filter(content -> !content.trim().isEmpty())
-                .orElseThrow(() -> new RestClientServerException("생성된 텍스트가 비어 있거나 응답이 없습니다"));
+                .orElseThrow(() -> new NonRetryableException("생성된 텍스트가 비어 있거나 응답이 없습니다"));
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/llm/OpenAIErrorHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/infrastructure/llm/OpenAIErrorHandler.java
@@ -1,14 +1,16 @@
 package feedzupzup.backend.feedback.infrastructure.llm;
 
-import static feedzupzup.backend.feedback.infrastructure.llm.OpenAIErrorResponse.*;
+import static feedzupzup.backend.feedback.infrastructure.llm.OpenAIErrorResponse.ErrorBody;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import feedzupzup.backend.global.exception.InfrastructureException.RestClientServerException;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
 import java.io.IOException;
 import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 
@@ -20,15 +22,47 @@ public class OpenAIErrorHandler {
     private final ObjectMapper objectMapper;
 
     public void handleError(final HttpRequest request, final ClientHttpResponse response) {
-        try (InputStream bodyStream = response.getBody()) {
-            final OpenAIErrorResponse errorResponse = objectMapper.readValue(bodyStream, OpenAIErrorResponse.class);
-            final ErrorBody errorBody = errorResponse.getError();
+        try {
+            final HttpStatus httpStatus = HttpStatus.valueOf(response.getStatusCode().value());
 
-            log.error("OpenAI API 실패 [{}:{}] {}", errorBody.getType(), errorBody.getCode(), errorBody.getMessage());
-            throw new RestClientServerException("OpenAI API를 실패하였습니다. request URI : " + request.getURI());
+            try (InputStream bodyStream = response.getBody()) {
+                final OpenAIErrorResponse errorResponse = objectMapper.readValue(bodyStream, OpenAIErrorResponse.class);
+                final ErrorBody errorBody = errorResponse.getError();
+                log.warn("OpenAI API 오류 [{}:{}] {}", errorBody.getType(), errorBody.getCode(),
+                        errorBody.getMessage());
+
+                if (isRetryableError(httpStatus, errorBody)) {
+                    throw new RetryableException(
+                            String.format("OpenAI API 일시적 오류 [%s]: %s", httpStatus, errorBody.getMessage()));
+                }
+                throw new NonRetryableException(
+                        String.format("OpenAI API 오류 [%s]: %s", httpStatus, errorBody.getMessage()));
+            }
         } catch (IOException e) {
             log.error("OpenAI Error Parsing Failed: {}", e.getMessage());
-            throw new RestClientServerException("OpenAI 에러 응답 파싱 실패", e);
+            throw new RetryableException("OpenAI 에러 응답 파싱 실패", e);
         }
+    }
+
+    private boolean isRetryableError(final HttpStatus httpStatus, final ErrorBody errorBody) {
+        if (
+            httpStatus == HttpStatus.TOO_MANY_REQUESTS ||
+            httpStatus == HttpStatus.REQUEST_TIMEOUT ||
+            httpStatus == HttpStatus.SERVICE_UNAVAILABLE ||
+            httpStatus == HttpStatus.BAD_GATEWAY ||
+            httpStatus == HttpStatus.GATEWAY_TIMEOUT ||
+            httpStatus.is5xxServerError()
+        ) {
+            return true;
+        }
+        if (errorBody == null || errorBody.getType() == null) {
+            return false;
+        }
+
+        String errorType = errorBody.getType().toLowerCase();
+        return errorType.contains("server_error") ||
+                errorType.contains("rate_limit") ||
+                errorType.contains("timeout") ||
+                errorType.contains("insufficient_quota");
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncFailureAlertService.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncFailureAlertService.java
@@ -1,0 +1,6 @@
+package feedzupzup.backend.global.async;
+
+public interface AsyncFailureAlertService {
+
+    void alert(final Long asyncTaskFailureId);
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailure.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailure.java
@@ -28,6 +28,7 @@ public class AsyncTaskFailure extends BaseTimeEntity {
     @Column(name = "task_type", nullable = false, length = 50)
     private TaskType taskType;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "target_type", nullable = false, length = 20)
     private TargetType targetType;
 

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailure.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailure.java
@@ -1,0 +1,101 @@
+package feedzupzup.backend.global.async;
+
+import feedzupzup.backend.global.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "async_task_failure")
+public class AsyncTaskFailure extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "task_type", nullable = false, length = 50)
+    private TaskType taskType;
+
+    @Column(name = "target_type", nullable = false, length = 20)
+    private TargetType targetType;
+
+    @Column(name = "target_id", nullable = false, length = 100)
+    private String targetId;
+
+    @Column(name = "error_message", nullable = false, columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "is_retryable", nullable = false)
+    private boolean retryable;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FailureStatus status;
+
+    @Builder
+    private AsyncTaskFailure(
+            final TaskType taskType,
+            final TargetType targetType,
+            final String targetId,
+            final String errorMessage,
+            final boolean retryable,
+            final FailureStatus status
+    ) {
+        this.taskType = taskType;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.errorMessage = errorMessage;
+        this.retryable = retryable;
+        this.status = status;
+    }
+
+    public static AsyncTaskFailure create(
+            final TaskType taskType,
+            final TargetType targetType,
+            final String targetId,
+            final String errorMessage,
+            final boolean retryable
+    ) {
+        if (retryable) {
+            return new AsyncTaskFailure(taskType, targetType, targetId, errorMessage, true, FailureStatus.PENDING);
+        }
+        return new AsyncTaskFailure(taskType, targetType, targetId, errorMessage, false, FailureStatus.FINAL_FAILED);
+    }
+
+    public void incrementRetryCount() {
+        if (this.retryCount >= 3) {
+            finalFailed();
+            throw new IllegalStateException("최대 재시도 횟수는 3회입니다. 그 이상 시도할 수 없습니다.");
+        }
+        this.retryCount++;
+        this.status = FailureStatus.RETRYING;
+    }
+
+    public boolean isFinalFailed() {
+        return this.status == FailureStatus.FINAL_FAILED;
+    }
+
+    public void finalFailed() {
+        this.retryable = false;
+        this.status = FailureStatus.FINAL_FAILED;
+    }
+
+    public boolean isMaxRetryCount() {
+        return this.retryCount == 3;
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureRepository.java
@@ -1,0 +1,9 @@
+package feedzupzup.backend.global.async;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface AsyncTaskFailureRepository extends JpaRepository<AsyncTaskFailure, Long> {
+
+    List<AsyncTaskFailure> findAllByRetryable(boolean retryable);
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureService.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureService.java
@@ -14,8 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AsyncTaskFailureService {
 
     private final AsyncTaskFailureRepository asyncTaskFailureRepository;
-    private final FeedbackClusteringService feedbackClusteringService;
     private final AsyncFailureAlertService asyncFailureAlertService;
+    private final FeedbackClusteringService feedbackClusteringService;
 
     @Transactional
     public Long recordFailure(

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureService.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureService.java
@@ -82,7 +82,11 @@ public class AsyncTaskFailureService {
                 asyncTaskFailureRepository.delete(failure);
                 log.info("클러스터 라벨 생성 재시도 성공: 클러스터ID={}", clusterId);
             }
-            default -> log.warn("알 수 없는 작업 타입: {}", taskType);
+            default -> {
+                log.warn("알 수 없는 작업 타입: {}", taskType);
+                failure.finalFailed();
+                throw new IllegalStateException("비동기 작업 종류를 taskType : " + taskType + " 처리할 수 없습니다.");
+            }
         }
     }
 

--- a/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureService.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/AsyncTaskFailureService.java
@@ -1,0 +1,93 @@
+package feedzupzup.backend.global.async;
+
+import feedzupzup.backend.feedback.application.FeedbackClusteringService;
+import feedzupzup.backend.global.async.exception.RetryableException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class AsyncTaskFailureService {
+
+    private final AsyncTaskFailureRepository asyncTaskFailureRepository;
+    private final FeedbackClusteringService feedbackClusteringService;
+    private final AsyncFailureAlertService asyncFailureAlertService;
+
+    @Transactional
+    public Long recordFailure(
+            final TaskType taskType,
+            final TargetType targetType,
+            final String targetId,
+            final Exception exception
+    ) {
+        String errorMessage = exception.getMessage();
+        boolean retryable = isRetryable(exception);
+        AsyncTaskFailure failure = AsyncTaskFailure.create(taskType, targetType, targetId, errorMessage, retryable);
+
+        log.warn("비동기 작업 실패 기록 - 작업: {}, 대상 타입 : {}, 대상ID: {}, 에러 클래스: {}",
+                taskType, targetType, targetId, exception.getClass().getSimpleName());
+        return asyncTaskFailureRepository.save(failure).getId();
+    }
+
+    private boolean isRetryable(final Exception exception) {
+        return exception instanceof RetryableException;
+    }
+
+    @Transactional
+    public void retry(final Long asyncTaskFailureId) {
+        AsyncTaskFailure failure = getById(asyncTaskFailureId);
+        try {
+            failure.incrementRetryCount();
+            log.error("현재 실패 작업 재시도 현황 - 작업: {}, 대상ID: {}, 재시도 횟수: {}, 재시도 가능여부 {}",
+                    failure.getTaskType(), failure.getTargetId(), failure.getRetryCount(), failure.isRetryable());
+            retryTask(failure);
+        } catch (Exception e) {
+            log.error("재시도 작업 실행 중 오류 발생: 작업={}, 대상ID={}", failure.getTaskType(), failure.getTargetId(), e);
+            if (failure.isMaxRetryCount() || failure.isFinalFailed()) {
+                failure.finalFailed();
+                alertFinalFail(failure.getId());
+            }
+        }
+    }
+
+    public void alertFinalFail(final Long asyncTaskFailureId) {
+        AsyncTaskFailure failure = getById(asyncTaskFailureId);
+        if (!failure.isFinalFailed()) {
+            log.info("finalFail만 알람을 보낼 수 있습니다.");
+            return;
+        }
+        asyncFailureAlertService.alert(asyncTaskFailureId);
+    }
+
+    private void retryTask(final AsyncTaskFailure failure) {
+        TaskType taskType = failure.getTaskType();
+        String targetId = failure.getTargetId();
+
+        log.info("작업 재시도 시작: 작업={}, 대상ID={}, 재시도 횟수={}", taskType, targetId, failure.getRetryCount());
+
+        switch (taskType) {
+            case FEEDBACK_CLUSTERING -> {
+                Long feedbackId = Long.valueOf(targetId);
+                feedbackClusteringService.cluster(feedbackId);
+                asyncTaskFailureRepository.delete(failure);
+                log.info("피드백 클러스터링 재시도 성공: 피드백ID={} 실패작업 기록 삭제 완료", feedbackId);
+            }
+            case CLUSTER_LABEL_GENERATION -> {
+                Long clusterId = Long.valueOf(targetId);
+                feedbackClusteringService.createLabel(clusterId);
+                asyncTaskFailureRepository.delete(failure);
+                log.info("클러스터 라벨 생성 재시도 성공: 클러스터ID={}", clusterId);
+            }
+            default -> log.warn("알 수 없는 작업 타입: {}", taskType);
+        }
+    }
+
+    private AsyncTaskFailure getById(final Long asyncTaskFailureId) {
+        return asyncTaskFailureRepository.findById(asyncTaskFailureId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 실패작업 ID(id:" + asyncTaskFailureId + ")로 찾을 수 없습니다."));
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/FailureRetryScheduler.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/FailureRetryScheduler.java
@@ -1,0 +1,31 @@
+package feedzupzup.backend.global.async;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FailureRetryScheduler {
+
+    private final AsyncTaskFailureRepository asyncTaskFailureRepository;
+    private final AsyncTaskFailureService asyncTaskFailureService;
+
+    @Scheduled(fixedDelayString = "${app.async.retry-scheduler.interval:300000}")
+    public void retryFailedTasks() {
+        List<AsyncTaskFailure> retryableFailures = asyncTaskFailureRepository.findAllByRetryable(true);
+        
+        if (retryableFailures.isEmpty()) {
+            return;
+        }
+        
+        log.info("재시도할 실패 작업 {} 개 발견", retryableFailures.size());
+
+        for (AsyncTaskFailure failure : retryableFailures) {
+            asyncTaskFailureService.retry(failure.getId());
+        }
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/FailureStatus.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/FailureStatus.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum FailureStatus {
     PENDING("대기 중"),
     RETRYING("재시도 중"),
-    FINAL_FAILED("최종 실패"),
-    RESOLVED("해결됨");
+    FINAL_FAILED("최종 실패")
+    ;
 
     private final String description;
 }

--- a/backend/src/main/java/feedzupzup/backend/global/async/FailureStatus.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/FailureStatus.java
@@ -1,0 +1,15 @@
+package feedzupzup.backend.global.async;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FailureStatus {
+    PENDING("대기 중"),
+    RETRYING("재시도 중"),
+    FINAL_FAILED("최종 실패"),
+    RESOLVED("해결됨");
+
+    private final String description;
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/TargetType.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/TargetType.java
@@ -1,0 +1,6 @@
+package feedzupzup.backend.global.async;
+
+public enum TargetType {
+    FEEDBACK,
+    FEEDBACK_CLUSTER,
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/TaskType.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/TaskType.java
@@ -1,16 +1,13 @@
 package feedzupzup.backend.global.async;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum TaskType {
     FEEDBACK_CLUSTERING("피드백 클러스터링"),
     CLUSTER_LABEL_GENERATION("클러스터 라벨 생성");
 
     private final String description;
-
-    TaskType(final String description) {
-        this.description = description;
-    }
-
-    public String getDescription() {
-        return description;
-    }
 }

--- a/backend/src/main/java/feedzupzup/backend/global/async/TaskType.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/TaskType.java
@@ -1,0 +1,16 @@
+package feedzupzup.backend.global.async;
+
+public enum TaskType {
+    FEEDBACK_CLUSTERING("피드백 클러스터링"),
+    CLUSTER_LABEL_GENERATION("클러스터 라벨 생성");
+
+    private final String description;
+
+    TaskType(final String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/exception/NonRetryableException.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/exception/NonRetryableException.java
@@ -1,0 +1,11 @@
+package feedzupzup.backend.global.async.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NonRetryableException extends RuntimeException {
+
+    public NonRetryableException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/exception/RetryableException.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/exception/RetryableException.java
@@ -1,0 +1,15 @@
+package feedzupzup.backend.global.async.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RetryableException extends RuntimeException {
+
+    public RetryableException(final String message) {
+        super(message);
+    }
+
+    public RetryableException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/infrastructure/AlertClientConfig.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/infrastructure/AlertClientConfig.java
@@ -1,0 +1,31 @@
+package feedzupzup.backend.global.async.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class AlertClientConfig {
+
+    @Value("${app.discord.webhook.url:}")
+    private String webhookUrl;
+
+    @Bean
+    public RestClient discordClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000); // 3초
+        factory.setReadTimeout(10000); // 10초
+
+        return RestClient.builder()
+                .baseUrl(webhookUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/async/infrastructure/DiscordAlertClient.java
+++ b/backend/src/main/java/feedzupzup/backend/global/async/infrastructure/DiscordAlertClient.java
@@ -1,0 +1,74 @@
+package feedzupzup.backend.global.async.infrastructure;
+
+import feedzupzup.backend.global.async.AsyncFailureAlertService;
+import feedzupzup.backend.global.async.AsyncTaskFailure;
+import feedzupzup.backend.global.async.AsyncTaskFailureRepository;
+import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DiscordAlertClient implements AsyncFailureAlertService {
+    //현재 디스코드 알람을 비동기 작업 실패 밖에 안써서 직접 구현하게 했으나, 추후 디스코드 알람을 다른 곳에서 쓴다면 분리해야할 필요성이 있음.
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Value("${app.discord.webhook.enabled:false}")
+    private boolean webhookEnabled;
+
+    private final AsyncTaskFailureRepository asyncTaskFailureRepository;
+    private final RestClient discordClient;
+
+    @Async("externalApiExecutor")
+    @Override
+    public void alert(final Long asyncTaskFailureId) {
+        if (!webhookEnabled) {
+            log.debug("Discord 웹훅이 비활성화되었거나 URL이 설정되지 않음");
+            return;
+        }
+        AsyncTaskFailure asyncTaskFailure = asyncTaskFailureRepository.findById(asyncTaskFailureId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 실패작업 ID(id:" + asyncTaskFailureId + ")로 찾을 수 없습니다."));
+
+        try {
+            String message = createFailureMessage(asyncTaskFailure);
+            discordClient.post()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("content", message))
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("Discord 알림 전송 완료: 작업={}, 대상ID={}",
+                    asyncTaskFailure.getTaskType(), asyncTaskFailure.getTargetId());
+
+        } catch (Exception e) {
+            log.error("Discord 알림 전송 실패: 작업={}, 대상ID={}",
+                    asyncTaskFailure.getTaskType(), asyncTaskFailure.getTargetId(), e);
+            throw e;
+        }
+    }
+
+    private String createFailureMessage(final AsyncTaskFailure failure) {
+        return String.format(
+                ":warning: **비동기 작업 최종 실패** :warning:\n\n" +
+                        "**작업 종류**: %s\n" +
+                        "**대상 ID**: %s\n" +
+                        "**재시도 횟수**: %d\n" +
+                        "**실패 시간**: %s\n" +
+                        "**에러 메시지**: ```%s```",
+                failure.getTaskType().getDescription(),
+                failure.getTargetId(),
+                failure.getRetryCount(),
+                failure.getCreatedAt().format(FORMATTER),
+                failure.getErrorMessage().length() > 500 ?
+                        failure.getErrorMessage().substring(0, 500) + "..." : failure.getErrorMessage()
+        );
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/AsyncConfig.java
@@ -1,10 +1,27 @@
 package feedzupzup.backend.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import java.util.concurrent.Executor;
 
-// TODO. 추후 ThreadPoolTaskExecutor 설정 추가 필요
 @Configuration
 @EnableAsync
+@EnableScheduling
 public class AsyncConfig {
+
+    @Bean(name = "externalApiExecutor")
+    public Executor externalApiExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("external-api-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
 }

--- a/backend/src/main/resources/db/migration/V39__create_async_task_failure_table.sql
+++ b/backend/src/main/resources/db/migration/V39__create_async_task_failure_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE async_task_failure
     target_type   VARCHAR(20)  NOT NULL,
     target_id     VARCHAR(100) NOT NULL,
     error_message TEXT         NOT NULL,
-    is_retryable  BOOLEAN      NOT NULL,
+    is_retryable  BIT(1)      NOT NULL,
     retry_count   INT          NOT NULL DEFAULT 0,
     status        VARCHAR(20)  NOT NULL,
     created_at    DATETIME(6)  NOT NULL,

--- a/backend/src/main/resources/db/migration/V39__create_async_task_failure_table.sql
+++ b/backend/src/main/resources/db/migration/V39__create_async_task_failure_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE async_task_failure
+(
+    id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    task_type     VARCHAR(50)  NOT NULL,
+    target_type   VARCHAR(20)  NOT NULL,
+    target_id     VARCHAR(100) NOT NULL,
+    error_message TEXT         NOT NULL,
+    is_retryable  BOOLEAN      NOT NULL,
+    retry_count   INT          NOT NULL DEFAULT 0,
+    status        VARCHAR(20)  NOT NULL,
+    created_at    DATETIME(6)  NOT NULL,
+    modified_at    DATETIME(6)  NOT NULL
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/FeedbackEmbeddingClusterServiceIntegrationTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/FeedbackEmbeddingClusterServiceIntegrationTest.java
@@ -72,8 +72,10 @@ class FeedbackEmbeddingClusterServiceIntegrationTest extends ServiceIntegrationH
             final Feedback savedSecondFeedback = feedbackRepository.save(secondFeedback);
 
             // when
-            FeedbackEmbeddingCluster firstCluster = feedbackClusteringService.cluster(savedFirstFeedback.getId());
-            FeedbackEmbeddingCluster secondCluster = feedbackClusteringService.cluster(savedSecondFeedback.getId());
+            Long firstClusterId = feedbackClusteringService.cluster(savedFirstFeedback.getId());
+            FeedbackEmbeddingCluster firstCluster = feedbackEmbeddingClusterRepository.findById(firstClusterId).get();
+            Long secondClusterId = feedbackClusteringService.cluster(savedSecondFeedback.getId());
+            FeedbackEmbeddingCluster secondCluster = feedbackEmbeddingClusterRepository.findById(secondClusterId).get();
 
             // then
             assertAll(
@@ -100,8 +102,10 @@ class FeedbackEmbeddingClusterServiceIntegrationTest extends ServiceIntegrationH
             final Feedback savedServiceFeedback = feedbackRepository.save(serviceFeedback);
 
             // when
-            FeedbackEmbeddingCluster foodCluster = feedbackClusteringService.cluster(savedFoodFeedback.getId());
-            FeedbackEmbeddingCluster serviceCluster = feedbackClusteringService.cluster(savedServiceFeedback.getId());
+            Long foodClusterId = feedbackClusteringService.cluster(savedFoodFeedback.getId());
+            FeedbackEmbeddingCluster foodCluster = feedbackEmbeddingClusterRepository.findById(foodClusterId).get();
+            Long serviceClusterId = feedbackClusteringService.cluster(savedServiceFeedback.getId());
+            FeedbackEmbeddingCluster serviceCluster = feedbackEmbeddingClusterRepository.findById(serviceClusterId).get();
 
             // then
             assertAll(
@@ -145,9 +149,12 @@ class FeedbackEmbeddingClusterServiceIntegrationTest extends ServiceIntegrationH
             final Feedback savedComplexITFeedback = feedbackRepository.save(complexITFeedback);
 
             // when
-            FeedbackEmbeddingCluster restaurantCluster1 = feedbackClusteringService.cluster(savedComplexRestaurantFeedback.getId());
-            FeedbackEmbeddingCluster restaurantCluster2 = feedbackClusteringService.cluster(savedSimilarRestaurantFeedback.getId());
-            FeedbackEmbeddingCluster itCluster = feedbackClusteringService.cluster(savedComplexITFeedback.getId());
+            Long restaurantCluster1Id = feedbackClusteringService.cluster(savedComplexRestaurantFeedback.getId());
+            FeedbackEmbeddingCluster restaurantCluster1 = feedbackEmbeddingClusterRepository.findById(restaurantCluster1Id).get();
+            Long restaurantCluster2Id = feedbackClusteringService.cluster(savedSimilarRestaurantFeedback.getId());
+            FeedbackEmbeddingCluster restaurantCluster2 = feedbackEmbeddingClusterRepository.findById(restaurantCluster2Id).get();
+            Long itClusterId = feedbackClusteringService.cluster(savedComplexITFeedback.getId());
+            FeedbackEmbeddingCluster itCluster = feedbackEmbeddingClusterRepository.findById(itClusterId).get();
 
             // then
             assertAll(
@@ -183,16 +190,17 @@ class FeedbackEmbeddingClusterServiceIntegrationTest extends ServiceIntegrationH
             final Feedback firstFeedback = FeedbackFixture.createFeedbackWithContent(
                     organization, positiveFoodReviews[0], organizationCategory);
             final Feedback savedFirstFeedback = feedbackRepository.save(firstFeedback);
-            FeedbackEmbeddingCluster firstCluster = feedbackClusteringService.cluster(savedFirstFeedback.getId());
+            Long firstClusterId = feedbackClusteringService.cluster(savedFirstFeedback.getId());
+            FeedbackEmbeddingCluster firstCluster = feedbackEmbeddingClusterRepository.findById(firstClusterId).get();
 
-            final Long firstClusterId = firstCluster.getEmbeddingCluster().getId();
+            final Long firstClusterEntityId = firstCluster.getEmbeddingCluster().getId();
 
             // when
             for (int i = 1; i < positiveFoodReviews.length; i++) {
                 final Feedback feedback = FeedbackFixture.createFeedbackWithContent(
                         organization, positiveFoodReviews[i], organizationCategory);
                 final Feedback savedFeedback = feedbackRepository.save(feedback);
-                feedbackClusteringService.cluster(savedFeedback.getId());
+                Long clusterId = feedbackClusteringService.cluster(savedFeedback.getId());
             }
 
             //then
@@ -236,9 +244,12 @@ class FeedbackEmbeddingClusterServiceIntegrationTest extends ServiceIntegrationH
             final Feedback savedNeutralEducationFeedback = feedbackRepository.save(neutralEducationFeedback);
 
             // when
-            FeedbackEmbeddingCluster positiveFoodCluster = feedbackClusteringService.cluster(savedPositiveFoodFeedback.getId());
-            FeedbackEmbeddingCluster negativeFoodCluster = feedbackClusteringService.cluster(savedNegativeFoodFeedback.getId());
-            FeedbackEmbeddingCluster educationCluster = feedbackClusteringService.cluster(savedNeutralEducationFeedback.getId());
+            Long positiveFoodClusterId = feedbackClusteringService.cluster(savedPositiveFoodFeedback.getId());
+            FeedbackEmbeddingCluster positiveFoodCluster = feedbackEmbeddingClusterRepository.findById(positiveFoodClusterId).get();
+            Long negativeFoodClusterId = feedbackClusteringService.cluster(savedNegativeFoodFeedback.getId());
+            FeedbackEmbeddingCluster negativeFoodCluster = feedbackEmbeddingClusterRepository.findById(negativeFoodClusterId).get();
+            Long educationClusterId = feedbackClusteringService.cluster(savedNeutralEducationFeedback.getId());
+            FeedbackEmbeddingCluster educationCluster = feedbackEmbeddingClusterRepository.findById(educationClusterId).get();
 
             // then
             assertAll(

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/event/FeedbackClusteringHandlerTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/event/FeedbackClusteringHandlerTest.java
@@ -1,0 +1,380 @@
+package feedzupzup.backend.feedback.application.event;
+
+import static feedzupzup.backend.global.async.TargetType.*;
+import static feedzupzup.backend.global.async.TaskType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import feedzupzup.backend.category.domain.Category;
+import feedzupzup.backend.category.domain.OrganizationCategory;
+import feedzupzup.backend.category.domain.OrganizationCategoryRepository;
+import feedzupzup.backend.category.fixture.OrganizationCategoryFixture;
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.feedback.application.FeedbackClusteringService;
+import feedzupzup.backend.feedback.domain.Feedback;
+import feedzupzup.backend.feedback.domain.FeedbackRepository;
+import feedzupzup.backend.feedback.domain.event.FeedbackCreatedEvent2;
+import feedzupzup.backend.feedback.fixture.FeedbackFixture;
+import feedzupzup.backend.global.async.AsyncFailureAlertService;
+import feedzupzup.backend.global.async.AsyncTaskFailure;
+import feedzupzup.backend.global.async.AsyncTaskFailureRepository;
+import feedzupzup.backend.global.async.AsyncTaskFailureService;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
+import feedzupzup.backend.organization.domain.Organization;
+import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.fixture.OrganizationFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.List;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private FeedbackClusteringHandler feedbackClusteringHandler;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private OrganizationCategoryRepository organizationCategoryRepository;
+
+    @Autowired
+    private AsyncTaskFailureRepository asyncTaskFailureRepository;
+
+    @Autowired
+    private AsyncTaskFailureService asyncTaskFailureService;
+
+    @MockitoBean
+    private FeedbackClusteringService feedbackClusteringService;
+
+    @MockitoBean
+    private AsyncFailureAlertService asyncFailureAlertService;
+
+    @Nested
+    @DisplayName("피드백 클러스터링 성공 테스트")
+    class ClusteringSuccessTest {
+
+        @Test
+        @DisplayName("정상적인 피드백 생성 이벤트 처리 시 클러스터링과 라벨 생성이 모두 성공한다")
+        void when_normal_feedback_event_then_clustering_and_label_generation_succeed() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.SUGGESTION)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "클러스터링 테스트용 피드백", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId())).thenReturn(999L);
+            doNothing().when(feedbackClusteringService).createLabel(999L);
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService).createLabel(999L),
+                () -> assertThat(asyncTaskFailureRepository.findAll()).isEmpty()
+            );
+        }
+
+        @Test
+        @DisplayName("클러스터링은 성공하지만 라벨 생성이 실패하는 경우 라벨 생성 실패만 기록된다")
+        void when_clustering_succeeds_but_label_generation_fails_then_only_label_failure_recorded() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.QUESTION)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "클러스터링은 성공, 라벨 실패 케이스", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId())).thenReturn(777L);
+            doThrow(new RetryableException("OpenAI API 타임아웃"))
+                .when(feedbackClusteringService).createLabel(777L);
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService).createLabel(777L),
+                () -> assertThat(failures).hasSize(1),
+                () -> {
+                    AsyncTaskFailure failure = failures.get(0);
+                    assertAll(
+                        () -> assertThat(failure.getTaskType()).isEqualTo(CLUSTER_LABEL_GENERATION),
+                        () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK),
+                        () -> assertThat(failure.getTargetId()).isEqualTo("777"),
+                        () -> assertThat(failure.getErrorMessage()).isEqualTo("OpenAI API 타임아웃"),
+                        () -> assertThat(failure.isRetryable()).isTrue()
+                    );
+                }
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백 클러스터링 실패 테스트")
+    class ClusteringFailureTest {
+
+        @Test
+        @DisplayName("재시도 가능한 예외 발생 시 실패가 기록되고 알람이 발송된다")
+        void when_retryable_exception_occurs_then_failure_recorded_and_alert_sent() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.FEEDBACK)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "네트워크 오류 테스트", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId()))
+                .thenThrow(new RetryableException("VoyageAI 연결 타임아웃"));
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService, never()).createLabel(any()),
+                () -> assertThat(failures).hasSize(1),
+                () -> {
+                    AsyncTaskFailure failure = failures.get(0);
+                    assertAll(
+                        () -> assertThat(failure.getTaskType()).isEqualTo(FEEDBACK_CLUSTERING),
+                        () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK_CLUSTER),
+                        () -> assertThat(failure.getTargetId()).isEqualTo(feedback.getId().toString()),
+                        () -> assertThat(failure.getErrorMessage()).isEqualTo("VoyageAI 연결 타임아웃"),
+                        () -> assertThat(failure.isRetryable()).isTrue()
+                    );
+                },
+                () -> verify(asyncFailureAlertService).alert(failures.get(0).getId())
+            );
+        }
+
+        @Test
+        @DisplayName("재시도 불가능한 예외 발생 시 최종 실패로 기록되고 알람이 발송된다")
+        void when_non_retryable_exception_occurs_then_final_failure_recorded_and_alert_sent() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.COMPLIMENT)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "인증 오류 테스트", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId()))
+                .thenThrow(new NonRetryableException("잘못된 API 키"));
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService, never()).createLabel(any()),
+                () -> assertThat(failures).hasSize(1),
+                () -> {
+                    AsyncTaskFailure failure = failures.get(0);
+                    assertAll(
+                        () -> assertThat(failure.getTaskType()).isEqualTo(FEEDBACK_CLUSTERING),
+                        () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK_CLUSTER),
+                        () -> assertThat(failure.getTargetId()).isEqualTo(feedback.getId().toString()),
+                        () -> assertThat(failure.getErrorMessage()).isEqualTo("잘못된 API 키"),
+                        () -> assertThat(failure.isRetryable()).isFalse()
+                    );
+                },
+                () -> verify(asyncFailureAlertService).alert(failures.get(0).getId())
+            );
+        }
+
+        @Test
+        @DisplayName("일반적인 런타임 예외 발생 시 재시도 불가능한 실패로 기록된다")
+        void when_generic_runtime_exception_occurs_then_non_retryable_failure_recorded() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.REPORT)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "예상치 못한 오류 테스트", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId()))
+                .thenThrow(new RuntimeException("예상치 못한 오류가 발생했습니다"));
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService, never()).createLabel(any()),
+                () -> assertThat(failures).hasSize(1),
+                () -> {
+                    AsyncTaskFailure failure = failures.get(0);
+                    assertAll(
+                        () -> assertThat(failure.getTaskType()).isEqualTo(FEEDBACK_CLUSTERING),
+                        () -> assertThat(failure.getTargetId()).isEqualTo(feedback.getId().toString()),
+                        () -> assertThat(failure.getErrorMessage()).isEqualTo("예상치 못한 오류가 발생했습니다"),
+                        () -> assertThat(failure.isRetryable()).isFalse()
+                    );
+                }
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("라벨 생성 실패 테스트")
+    class LabelGenerationFailureTest {
+
+        @Test
+        @DisplayName("라벨 생성에서 재시도 가능한 예외 발생 시 실패가 기록된다")
+        void when_label_generation_retryable_exception_then_failure_recorded() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.SHARING)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "라벨 생성 실패 테스트", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId())).thenReturn(555L);
+            doThrow(new RetryableException("OpenAI Rate limit 초과"))
+                .when(feedbackClusteringService).createLabel(555L);
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService).createLabel(555L),
+                () -> assertThat(failures).hasSize(1),
+                () -> {
+                    AsyncTaskFailure failure = failures.get(0);
+                    assertAll(
+                        () -> assertThat(failure.getTaskType()).isEqualTo(CLUSTER_LABEL_GENERATION),
+                        () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK),
+                        () -> assertThat(failure.getTargetId()).isEqualTo("555"),
+                        () -> assertThat(failure.getErrorMessage()).isEqualTo("OpenAI Rate limit 초과"),
+                        () -> assertThat(failure.isRetryable()).isTrue()
+                    );
+                }
+            );
+        }
+
+        @Test
+        @DisplayName("라벨 생성에서 재시도 불가능한 예외 발생 시 최종 실패로 기록된다")
+        void when_label_generation_non_retryable_exception_then_final_failure_recorded() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization, Category.ETC)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "라벨 생성 최종 실패 테스트", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            
+            when(feedbackClusteringService.cluster(feedback.getId())).thenReturn(888L);
+            doThrow(new NonRetryableException("OpenAI 모델 접근 권한 없음"))
+                .when(feedbackClusteringService).createLabel(888L);
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(feedback.getId()),
+                () -> verify(feedbackClusteringService).createLabel(888L),
+                () -> assertThat(failures).hasSize(1),
+                () -> {
+                    AsyncTaskFailure failure = failures.get(0);
+                    assertAll(
+                        () -> assertThat(failure.getTaskType()).isEqualTo(CLUSTER_LABEL_GENERATION),
+                        () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK),
+                        () -> assertThat(failure.getTargetId()).isEqualTo("888"),
+                        () -> assertThat(failure.getErrorMessage()).isEqualTo("OpenAI 모델 접근 권한 없음"),
+                        () -> assertThat(failure.isRetryable()).isFalse()
+                    );
+                }
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 처리 검증 테스트")
+    class FailureHandlingVerificationTest {
+
+        @Test
+        @DisplayName("실패 기록 후 적절한 서비스 메서드가 호출되는지 검증")
+        void verify_failure_service_methods_are_called_correctly() {
+            // given
+            Organization organization = organizationRepository.save(OrganizationFixture.createAllBlackBox());
+            OrganizationCategory category = organizationCategoryRepository.save(
+                OrganizationCategoryFixture.createOrganizationCategory(organization)
+            );
+            Feedback feedback = feedbackRepository.save(
+                FeedbackFixture.createFeedback(organization, "서비스 메서드 호출 검증", category)
+            );
+            
+            FeedbackCreatedEvent2 event = new FeedbackCreatedEvent2(feedback.getId());
+            RetryableException exception = new RetryableException("네트워크 연결 실패");
+            
+            when(feedbackClusteringService.cluster(feedback.getId())).thenThrow(exception);
+            
+            // when
+            feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
+            
+            // then
+            verify(asyncTaskFailureService).recordFailure(
+                FEEDBACK_CLUSTERING, 
+                FEEDBACK_CLUSTER, 
+                feedback.getId().toString(), 
+                exception
+            );
+            verify(asyncTaskFailureService).alertFinalFail(anyLong());
+        }
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/event/FeedbackClusteringHandlerTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/event/FeedbackClusteringHandlerTest.java
@@ -2,7 +2,9 @@ package feedzupzup.backend.feedback.application.event;
 
 import static feedzupzup.backend.global.async.TargetType.*;
 import static feedzupzup.backend.global.async.TaskType.*;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -30,8 +32,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import java.util.List;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -87,6 +87,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
                 () -> verify(feedbackClusteringService).createLabel(999L),
@@ -116,6 +120,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
@@ -160,6 +168,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
@@ -200,6 +212,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
@@ -240,6 +256,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
@@ -284,6 +304,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
@@ -324,6 +348,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             List<AsyncTaskFailure> failures = asyncTaskFailureRepository.findAll();
             assertAll(
                 () -> verify(feedbackClusteringService).cluster(feedback.getId()),
@@ -368,6 +396,10 @@ class FeedbackClusteringHandlerTest extends ServiceIntegrationHelper {
             feedbackClusteringHandler.handleFeedbackCreatedEvent(event);
             
             // then
+            await().atMost(1, SECONDS)
+                    .untilAsserted(() ->
+                            verify(feedbackClusteringService).cluster(feedback.getId())
+                    );
             verify(asyncTaskFailureService).recordFailure(
                 FEEDBACK_CLUSTERING, 
                 FEEDBACK_CLUSTER, 

--- a/backend/src/test/java/feedzupzup/backend/feedback/infrastructure/embedding/OpenAICompletionClientTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/infrastructure/embedding/OpenAICompletionClientTest.java
@@ -1,4 +1,4 @@
-package feedzupzup.backend.feedback.infrastructure.llm;
+package feedzupzup.backend.feedback.infrastructure.embedding;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -7,6 +7,12 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import feedzupzup.backend.feedback.infrastructure.llm.OpenAICompletionClient;
+import feedzupzup.backend.feedback.infrastructure.llm.OpenAICompletionResponse;
+import feedzupzup.backend.feedback.infrastructure.llm.OpenAIErrorHandler;
+import feedzupzup.backend.feedback.infrastructure.llm.OpenAIProperties;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
 import feedzupzup.backend.global.exception.InfrastructureException.RestClientServerException;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +111,7 @@ class OpenAICompletionClientTest {
 
         // when & then
         assertThatThrownBy(() -> openAICompletionClient.generateCompletion(prompt, systemMessage))
-                .isInstanceOf(RestClientServerException.class)
+                .isInstanceOf(RetryableException.class)
                 .hasMessageContaining("생성된 텍스트가 비어 있거나 응답이 없습니다");
     }
 
@@ -131,7 +137,7 @@ class OpenAICompletionClientTest {
 
         // when & then
         assertThatThrownBy(() -> openAICompletionClient.generateCompletion(prompt, systemMessage))
-                .isInstanceOf(RestClientServerException.class)
+                .isInstanceOf(RetryableException.class)
                 .hasMessageContaining("생성된 텍스트가 비어 있거나 응답이 없습니다");
     }
 
@@ -163,26 +169,7 @@ class OpenAICompletionClientTest {
 
         // when & then
         assertThatThrownBy(() -> openAICompletionClient.generateCompletion(prompt, systemMessage))
-                .isInstanceOf(RestClientServerException.class)
+                .isInstanceOf(RetryableException.class)
                 .hasMessageContaining("생성된 텍스트가 비어 있거나 응답이 없습니다");
-    }
-
-    @Test
-    @DisplayName("API 호출 중 예외 발생 시 RestClientServerException 발생")
-    void generateCompletion_ThrowRestClientServerException_WhenAPICallFails() {
-        // given
-        final String prompt = "테스트 프롬프트";
-        final String systemMessage = "시스템 메시지";
-
-        given(openAIProperties.getCompletionModel()).willReturn("gpt-3.5-turbo");
-        given(openAIProperties.getMaxTokens()).willReturn(1000);
-        given(openAIProperties.getTemperature()).willReturn(0.7);
-
-        when(openAiCompletionRestClient.post()).thenThrow(new RuntimeException("API 호출 실패"));
-
-        // when & then
-        assertThatThrownBy(() -> openAICompletionClient.generateCompletion(prompt, systemMessage))
-                .isInstanceOf(RestClientServerException.class)
-                .hasMessageContaining("피드백 라벨 생성 중 오류 발생");
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIEmbeddingClientTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/infrastructure/embedding/VoyageAIEmbeddingClientTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import feedzupzup.backend.global.async.exception.RetryableException;
 import feedzupzup.backend.global.exception.InfrastructureException.RestClientServerException;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +101,7 @@ class VoyageAIEmbeddingClientTest {
 
         // when & then
         assertThatThrownBy(() -> voyageAIEmbeddingClient.extractEmbedding(inputText))
-                .isInstanceOf(RestClientServerException.class)
+                .isInstanceOf(RetryableException.class)
                 .hasMessageContaining("임베딩 데이터가 비어 있거나 응답이 없습니다");
     }
 
@@ -122,26 +123,5 @@ class VoyageAIEmbeddingClientTest {
         assertThatThrownBy(() -> voyageAIEmbeddingClient.extractEmbedding(inputText))
                 .isInstanceOf(Exception.class)
                 .hasMessageContaining("임베딩 데이터가 비어 있거나 응답이 없습니다");
-    }
-
-    @Test
-    @DisplayName("RestClient 예외 발생 시 RestClientServerException으로 변환한다")
-    void extractEmbedding_RestClientException_ThrowsRestClientServerException() {
-        // given
-        String inputText = "테스트 입력 텍스트";
-        String model = "voyage-3-large";
-
-        given(voyageAIProperties.getEmbeddingModel()).willReturn(model);
-        given(voyageAiEmbeddingRestClient.post()).willReturn(requestBodyUriSpec);
-        given(requestBodyUriSpec.body(any(Map.class))).willReturn(requestBodySpec);
-        given(requestBodySpec.retrieve()).willReturn(responseSpec);
-        given(responseSpec.onStatus(any(), any())).willReturn(responseSpec);
-        given(responseSpec.body(VoyageAIEmbeddingResponse.class))
-                .willThrow(new RestClientException("네트워크 오류"));
-
-        // when & then
-        assertThatThrownBy(() -> voyageAIEmbeddingClient.extractEmbedding(inputText))
-                .isInstanceOf(RestClientServerException.class)
-                .hasMessageContaining("임베딩 생성 중 오류 발생");
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/global/async/AsyncTaskFailureServiceTest.java
+++ b/backend/src/test/java/feedzupzup/backend/global/async/AsyncTaskFailureServiceTest.java
@@ -1,0 +1,211 @@
+package feedzupzup.backend.global.async;
+
+import static feedzupzup.backend.global.async.FailureStatus.*;
+import static feedzupzup.backend.global.async.TargetType.*;
+import static feedzupzup.backend.global.async.TaskType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.feedback.application.FeedbackClusteringService;
+import feedzupzup.backend.global.async.exception.NonRetryableException;
+import feedzupzup.backend.global.async.exception.RetryableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class AsyncTaskFailureServiceTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private AsyncTaskFailureService asyncTaskFailureService;
+
+    @Autowired
+    private AsyncTaskFailureRepository asyncTaskFailureRepository;
+
+    @MockitoBean
+    private FeedbackClusteringService feedbackClusteringService;
+
+    @MockitoBean
+    private AsyncFailureAlertService asyncFailureAlertService;
+
+    @Nested
+    @DisplayName("실패 기록 테스트")
+    class RecordFailureTest {
+
+        @Test
+        @DisplayName("RetryableException 발생 시 재시도 가능한 실패로 기록된다")
+        void when_retryable_exception_then_record_as_retryable() {
+            // given
+            RetryableException exception = new RetryableException("VoyageAI 타임아웃 발생");
+            
+            // when
+            Long failureId = asyncTaskFailureService.recordFailure(
+                FEEDBACK_CLUSTERING, 
+                FEEDBACK_CLUSTER, 
+                "123", 
+                exception
+            );
+            
+            // then
+            AsyncTaskFailure failure = asyncTaskFailureRepository.findById(failureId).orElseThrow();
+            assertAll(
+                () -> assertThat(failure.getTaskType()).isEqualTo(FEEDBACK_CLUSTERING),
+                () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK_CLUSTER),
+                () -> assertThat(failure.getTargetId()).isEqualTo("123"),
+                () -> assertThat(failure.getErrorMessage()).isEqualTo("VoyageAI 타임아웃 발생"),
+                () -> assertThat(failure.isRetryable()).isTrue(),
+                () -> assertThat(failure.getStatus()).isEqualTo(PENDING),
+                () -> assertThat(failure.getRetryCount()).isEqualTo(0)
+            );
+        }
+
+        @Test
+        @DisplayName("NonRetryableException 발생 시 재시도 불가능한 최종 실패로 기록된다")
+        void when_non_retryable_exception_then_record_as_final_failed() {
+            // given
+            NonRetryableException exception = new NonRetryableException("잘못된 API 키");
+            
+            // when
+            Long failureId = asyncTaskFailureService.recordFailure(
+                CLUSTER_LABEL_GENERATION, 
+                FEEDBACK, 
+                "456", 
+                exception
+            );
+            
+            // then
+            AsyncTaskFailure failure = asyncTaskFailureRepository.findById(failureId).orElseThrow();
+            assertAll(
+                () -> assertThat(failure.getTaskType()).isEqualTo(CLUSTER_LABEL_GENERATION),
+                () -> assertThat(failure.getTargetType()).isEqualTo(FEEDBACK),
+                () -> assertThat(failure.getTargetId()).isEqualTo("456"),
+                () -> assertThat(failure.getErrorMessage()).isEqualTo("잘못된 API 키"),
+                () -> assertThat(failure.isRetryable()).isFalse(),
+                () -> assertThat(failure.getStatus()).isEqualTo(FINAL_FAILED),
+                () -> assertThat(failure.getRetryCount()).isEqualTo(0)
+            );
+        }
+
+        @Test
+        @DisplayName("일반 Exception 발생 시 재시도 불가능한 최종 실패로 기록된다")
+        void when_generic_exception_then_record_as_non_retryable() {
+            // given
+            RuntimeException exception = new RuntimeException("예상치 못한 오류");
+            
+            // when
+            Long failureId = asyncTaskFailureService.recordFailure(
+                FEEDBACK_CLUSTERING, 
+                FEEDBACK_CLUSTER, 
+                "789", 
+                exception
+            );
+            
+            // then
+            AsyncTaskFailure failure = asyncTaskFailureRepository.findById(failureId).orElseThrow();
+            assertAll(
+                () -> assertThat(failure.isRetryable()).isFalse(),
+                () -> assertThat(failure.getStatus()).isEqualTo(FINAL_FAILED),
+                () -> assertThat(failure.getErrorMessage()).isEqualTo("예상치 못한 오류")
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("최종 실패 알람 테스트")
+    class AlertFinalFailTest {
+
+        @Test
+        @DisplayName("최종 실패 상태인 경우 알람이 발송된다")
+        void when_final_failed_then_alert_is_sent() {
+            // given
+            AsyncTaskFailure failure = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "123", "API 키 오류", false
+            );
+            asyncTaskFailureRepository.save(failure);
+
+            // when
+            asyncTaskFailureService.alertFinalFail(failure.getId());
+
+            // then
+            verify(asyncFailureAlertService).alert(failure.getId());
+        }
+
+        @Test
+        @DisplayName("최종 실패 상태가 아닌 경우 알람이 발송되지 않는다")
+        void when_not_final_failed_then_alert_is_not_sent() {
+            // given
+            AsyncTaskFailure failure = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "123", "타임아웃 오류", true
+            );
+            asyncTaskFailureRepository.save(failure);
+
+            // when
+            asyncTaskFailureService.alertFinalFail(failure.getId());
+
+            // then
+            verifyNoInteractions(asyncFailureAlertService);
+        }
+    }
+
+    @Nested
+    @DisplayName("작업 재시도 테스트")
+    class RetryTaskTest {
+
+        @Test
+        @DisplayName("피드백 클러스터링 작업이 성공적으로 재시도된다")
+        void when_feedback_clustering_retry_then_success() {
+            // given
+            AsyncTaskFailure failure = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "123", "타임아웃 오류", true
+            );
+            asyncTaskFailureRepository.save(failure);
+            
+            when(feedbackClusteringService.cluster(123L)).thenReturn(456L);
+            
+            // when
+            asyncTaskFailureService.retry(failure.getId());
+            
+            // then
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(123L),
+                () -> assertThat(asyncTaskFailureRepository.findById(failure.getId())).isEmpty()
+            );
+        }
+
+        @Test
+        @DisplayName("클러스터 라벨 생성 작업이 성공적으로 재시도된다")
+        void when_cluster_label_generation_retry_then_success() {
+            // given
+            AsyncTaskFailure failure = AsyncTaskFailure.create(
+                CLUSTER_LABEL_GENERATION, FEEDBACK, "789", "API 오류", true
+            );
+            asyncTaskFailureRepository.save(failure);
+            
+            doNothing().when(feedbackClusteringService).createLabel(789L);
+            
+            // when
+            asyncTaskFailureService.retry(failure.getId());
+            
+            // then
+            assertAll(
+                () -> verify(feedbackClusteringService).createLabel(789L),
+                () -> assertThat(asyncTaskFailureRepository.findById(failure.getId())).isEmpty()
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 실패 작업 ID로 재시도 시 예외가 발생한다")
+        void when_retry_with_non_existing_id_then_throw_exception() {
+            // given
+            Long nonExistingId = 999L;
+            
+            // when & then
+            assertThatThrownBy(() -> asyncTaskFailureService.retry(nonExistingId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("해당 실패작업 ID(id:" + nonExistingId + ")로 찾을 수 없습니다");
+        }
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/global/async/FailureRetrySchedulerTest.java
+++ b/backend/src/test/java/feedzupzup/backend/global/async/FailureRetrySchedulerTest.java
@@ -1,0 +1,127 @@
+package feedzupzup.backend.global.async;
+
+import static feedzupzup.backend.global.async.FailureStatus.*;
+import static feedzupzup.backend.global.async.TargetType.*;
+import static feedzupzup.backend.global.async.TaskType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.feedback.application.FeedbackClusteringService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+class FailureRetrySchedulerTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private FailureRetryScheduler failureRetryScheduler;
+
+    @Autowired
+    private AsyncTaskFailureRepository asyncTaskFailureRepository;
+
+    @MockitoSpyBean
+    private AsyncTaskFailureService asyncTaskFailureService;
+
+    @MockitoBean
+    private FeedbackClusteringService feedbackClusteringService;
+
+    @Nested
+    @DisplayName("재시도 스케줄러 테스트")
+    class RetrySchedulerTest {
+
+        @Test
+        @DisplayName("재시도 가능한 실패 작업들이 스케줄러에 의해 처리된다")
+        void when_retryable_failures_exist_then_they_are_processed() {
+            // given
+            AsyncTaskFailure retryableFailure1 = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "123", "타임아웃 오류 1", true
+            );
+            AsyncTaskFailure retryableFailure2 = AsyncTaskFailure.create(
+                CLUSTER_LABEL_GENERATION, FEEDBACK, "456", "타임아웃 오류 2", true
+            );
+            AsyncTaskFailure nonRetryableFailure = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "789", "API 키 오류", false
+            );
+            
+            asyncTaskFailureRepository.save(retryableFailure1);
+            asyncTaskFailureRepository.save(retryableFailure2);
+            asyncTaskFailureRepository.save(nonRetryableFailure);
+            
+            when(feedbackClusteringService.cluster(123L)).thenReturn(999L);
+            doNothing().when(feedbackClusteringService).createLabel(456L);
+            
+            // when
+            failureRetryScheduler.retryFailedTasks();
+            
+            // then
+            verify(asyncTaskFailureService).retry(retryableFailure1.getId());
+            verify(asyncTaskFailureService).retry(retryableFailure2.getId());
+            
+            // 재시도 불가능한 실패는 처리되지 않음
+            verify(asyncTaskFailureService, never()).retry(nonRetryableFailure.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("통합 시나리오 테스트")
+    class IntegrationScenarioTest {
+
+        @Test
+        @DisplayName("전체 재시도 프로세스가 정상적으로 동작한다")
+        void complete_retry_process_works_correctly() {
+            // given
+            AsyncTaskFailure failure = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "123", "네트워크 타임아웃", true
+            );
+            asyncTaskFailureRepository.save(failure);
+            
+            when(feedbackClusteringService.cluster(123L)).thenReturn(999L);
+            
+            // when
+            failureRetryScheduler.retryFailedTasks();
+            
+            // then
+            AsyncTaskFailure updatedFailure = asyncTaskFailureRepository.findById(failure.getId()).orElse(null);
+            
+            assertAll(
+                () -> verify(feedbackClusteringService).cluster(123L),
+                () -> assertThat(updatedFailure).isNull(), // 성공 후 삭제됨
+                () -> verify(asyncTaskFailureService).retry(failure.getId())
+            );
+        }
+
+        @Test
+        @DisplayName("3회 재시도 후 최종 실패된다")
+        void after_three_retries_final_failure_and_alert_sent() {
+            // given
+            AsyncTaskFailure failure = AsyncTaskFailure.create(
+                FEEDBACK_CLUSTERING, FEEDBACK_CLUSTER, "123", "지속적인 네트워크 오류", true
+            );
+            
+            // 이미 2번 재시도한 상태
+            failure.incrementRetryCount();
+            failure.incrementRetryCount();
+            asyncTaskFailureRepository.save(failure);
+
+            // 3번째 재시도도 실패
+            when(feedbackClusteringService.cluster(123L))
+                    .thenThrow(new RuntimeException("여전히 실패"));
+
+            // when
+            failureRetryScheduler.retryFailedTasks();
+            
+            // then
+            AsyncTaskFailure finalFailure = asyncTaskFailureRepository.findById(failure.getId()).orElseThrow();
+            
+            assertAll(
+                () -> assertThat(finalFailure.getRetryCount()).isEqualTo(3),
+                () -> assertThat(finalFailure.getStatus()).isEqualTo(FINAL_FAILED)
+            );
+        }
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/global/async/infrastructure/DiscordAlertClientTest.java
+++ b/backend/src/test/java/feedzupzup/backend/global/async/infrastructure/DiscordAlertClientTest.java
@@ -14,10 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = {
-        "app.discord.webhook.enabled=true",
-        "app.discord.webhook.url=https://discord.com/api/webhooks/1393461237223919646/J-qWfcqrnNUxlu_lIJwr5Q9ARDZdxpUurW6Fs0yCmyX0plYMXrTlRPDXnBzdtPzo031E"
-})
 @Disabled
 class DiscordAlertClientTest extends ServiceIntegrationHelper {
 

--- a/backend/src/test/java/feedzupzup/backend/global/async/infrastructure/DiscordAlertClientTest.java
+++ b/backend/src/test/java/feedzupzup/backend/global/async/infrastructure/DiscordAlertClientTest.java
@@ -1,0 +1,48 @@
+package feedzupzup.backend.global.async.infrastructure;
+
+import static feedzupzup.backend.global.async.TargetType.FEEDBACK;
+import static feedzupzup.backend.global.async.TaskType.CLUSTER_LABEL_GENERATION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import feedzupzup.backend.config.ServiceIntegrationHelper;
+import feedzupzup.backend.global.async.AsyncFailureAlertService;
+import feedzupzup.backend.global.async.AsyncTaskFailure;
+import feedzupzup.backend.global.async.AsyncTaskFailureRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {
+        "app.discord.webhook.enabled=true",
+        "app.discord.webhook.url=https://discord.com/api/webhooks/1393461237223919646/J-qWfcqrnNUxlu_lIJwr5Q9ARDZdxpUurW6Fs0yCmyX0plYMXrTlRPDXnBzdtPzo031E"
+})
+@Disabled
+class DiscordAlertClientTest extends ServiceIntegrationHelper {
+
+    @Autowired
+    private AsyncFailureAlertService asyncFailureAlertService;
+
+    @Autowired
+    private AsyncTaskFailureRepository asyncTaskFailureRepository;
+
+    @Test
+    @DisplayName("재시도 불가능한 실패에 대한 Discord 알람이 정상적으로 전송된다")
+    void when_non_retryable_failure_then_discord_alert_sent_successfully() {
+        // given
+        AsyncTaskFailure failure = AsyncTaskFailure.create(
+                CLUSTER_LABEL_GENERATION,
+                FEEDBACK,
+                "67890",
+                "OpenAI API 인증 실패: 잘못된 API 키가 제공되었습니다.",
+                false
+        );
+        AsyncTaskFailure savedFailure = asyncTaskFailureRepository.save(failure);
+
+        // when & then - 실제 Discord 전송은 외부 의존성이므로 예외가 발생하지 않음을 확인
+        assertDoesNotThrow(() -> {
+            asyncFailureAlertService.alert(savedFailure.getId());
+        });
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#1018 

## 🚀 작업 내용

### 기존 비동기 작업 실패시 대응
<img width="2906" height="887" alt="image" src="https://github.com/user-attachments/assets/7163f1af-4e14-4314-aedb-f4166921a5cc" />

기존에는 단순히 비동기 작업 실패 시, 예외처리 및 로그만 작성하고 있었습니다.

### 변경 후 비동기 작업 실패시 대응

<img width="3744" height="1725" alt="image" src="https://github.com/user-attachments/assets/4533ece6-f2c8-4e25-99f0-bcb86af6c562" />

비동기 작업은 피드백 클러스터링 작업으로 외부 API에 의존하고 있습니다.
외부 API는 네트워크를 통해 실행되는 작업이므로 외부 API 장애, 타임아웃, Rate Limit 등 의도치 않게 실패할 경우가 있습니다.
이때 피드백이 유실되는 것을 방지하고자 위 플로우를 설계 했습니다.

1. 지수 백오프 방식으로 재시도 (200ms -> 400ms -> 800ms)
2. 즉시 재시도 실패, 재시도 불가능한 예외인 경우 AsynkTaskFailure 테이블에 저장
3. 재시도 가능, 불가능을 판단해 저장한 후 스케줄링으로 재시도
4. 재시도 불가능한 상태는 개발자 디스코드에게 알림

파일 크기가 좀 큰데, 커밋별로 읽으면 좋을 것 같아요

### 기대하는 바
최대한 비동기 작업에 대한 최종적 일관성을 보장하고자 했습니다.
피드백 클러스터링은 실시간이 크게 중요한 작업이기 보다 일관성이 중요한 작업이므로 재시도 스케줄링 작업을 구현했습니다~

재시도 불가능 예외는 개발자가 수동으로 처리하게 되어있는데, 현재는 소규모라 괜찮을 것이라 판단했습니다.
나중에 실패가 정말 많아진다면, 다른 흐름을 생각해봐야할 것 같아요

## 💬 리뷰 중점사항
RateLimiter는 적용하지 않았습니다.
스케줄링 때 한번에 많은 양을 스케줄링한다면 외부 API가 장애가 발생할까 RateLimiter 도입을 고려해봤는데요, 실패하는 작업이 크게 많지 않은 것 같아서 일단 구현하지 않았습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 외부 API 호출 자동 재시도(지수 백오프) 적용
  * 비동기 작업 실패 기록·관리 서비스 및 Discord 웹훅 알림 추가
  * 실패 작업 자동 재시도 스케줄러와 전용 실행자(Executor) 추가

* **개선사항**
  * 오류를 재시도 가능/불가능으로 분류해 안정성·로깅·알림 체계 강화

* **테스트**
  * 비동기 실패 처리·재시도·알림 경로에 대한 단위·통합 테스트 대폭 추가

* **데이터베이스**
  * 비동기 실패 기록용 테이블 추가 마이그레이션

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->