### PR TITLE
[FE] feat: 가상스크롤 도입 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@sentry/react": "^9.42.1",
         "@tanstack/react-query": "^5.85.0",
         "@tanstack/react-query-devtools": "^5.85.3",
+        "@tanstack/react-virtual": "^3.13.12",
         "browser-image-compression": "^2.0.2",
         "dotenv": "^17.2.0",
         "firebase": "^12.1.0",
@@ -6397,6 +6398,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.1",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/cypress": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@sentry/react": "^9.42.1",
     "@tanstack/react-query": "^5.85.0",
     "@tanstack/react-query-devtools": "^5.85.3",
+    "@tanstack/react-virtual": "^3.13.12",
     "browser-image-compression": "^2.0.2",
     "dotenv": "^17.2.0",
     "firebase": "^12.1.0",

--- a/frontend/src/domains/components/FeedbackBoxList/FeedbackBoxList.tsx
+++ b/frontend/src/domains/components/FeedbackBoxList/FeedbackBoxList.tsx
@@ -1,9 +1,14 @@
+import { SerializedStyles } from '@emotion/react';
 import { container } from './FeedbackBoxList.styles';
 
 interface FeedbackBoxListProps {
   children: React.ReactNode;
+  customCSS?: SerializedStyles;
 }
 
-export default function FeedbackBoxList({ children }: FeedbackBoxListProps) {
-  return <section css={container}>{children}</section>;
+export default function FeedbackBoxList({
+  customCSS,
+  children,
+}: FeedbackBoxListProps) {
+  return <section css={[container, customCSS]}>{children}</section>;
 }

--- a/frontend/src/domains/components/VirtualFeedbackItem/VirtualFeedbackItem.tsx
+++ b/frontend/src/domains/components/VirtualFeedbackItem/VirtualFeedbackItem.tsx
@@ -1,0 +1,33 @@
+import { VirtualItem } from '@tanstack/react-virtual';
+import { ReactNode } from 'react';
+
+interface FeedbackItemProps {
+  measureElement: (node: HTMLElement | null) => void;
+  virtualRow: VirtualItem;
+  children: ReactNode;
+}
+
+function VirtualFeedbackItem({
+  children,
+  measureElement,
+  virtualRow,
+}: FeedbackItemProps) {
+  return (
+    <div
+      key={virtualRow.key}
+      data-index={virtualRow.index}
+      ref={measureElement}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        transform: `translateY(${virtualRow.start}px)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default VirtualFeedbackItem;

--- a/frontend/src/domains/user/userDashboard/UserDashboard.style.ts
+++ b/frontend/src/domains/user/userDashboard/UserDashboard.style.ts
@@ -45,5 +45,8 @@ export const myFeedbackStyle = (theme: Theme, isMyFeedback: boolean) => css`
 `;
 
 export const skipTarget = css`
-  scroll-margin-top: 100px;
+  height: 100vh;
+  /* scroll-margin-top: 100px; */
+  overflow: auto;
+  position: relative;
 `;

--- a/frontend/src/domains/user/userDashboard/UserDashboard.tsx
+++ b/frontend/src/domains/user/userDashboard/UserDashboard.tsx
@@ -35,7 +35,7 @@ export default function UserDashboard() {
   };
 
   return (
-    <>
+    <div>
       <SEO
         title='피드백 방'
         description='제출된 피드백을 확인하세요'
@@ -73,6 +73,6 @@ export default function UserDashboard() {
           />
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/src/domains/user/userDashboard/components/UserFeedbackList/UserFeedbackList.tsx
+++ b/frontend/src/domains/user/userDashboard/components/UserFeedbackList/UserFeedbackList.tsx
@@ -1,12 +1,9 @@
-import useGetFeedback from '@/domains/admin/adminDashboard/hooks/useGetFeedback';
-import FeedbackBoxList from '@/domains/components/FeedbackBoxList/FeedbackBoxList';
 import FeedbackBoxSkeletonList from '@/domains/components/FeedbackBoxSkeleton/FeedbackBoxSkeletonList';
+import VirtualFeedbackItem from '@/domains/components/VirtualFeedbackItem/VirtualFeedbackItem';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
 import UserFeedbackBox from '@/domains/user/userDashboard/components/UserFeedbackBox/UserFeedbackBox';
 import useHighLighted from '@/domains/user/userDashboard/hooks/useHighLighted';
 import useMyLikedFeedback from '@/domains/user/userDashboard/hooks/useMyLikedFeedback';
-import { skipTarget } from '@/domains/user/userDashboard/UserDashboard.style';
-import { srFeedbackSummary } from '@/domains/user/userDashboard/utils/srFeedbackSummary';
 import { createFeedbacksUrl } from '@/domains/utils/createFeedbacksUrl';
 import useCursorInfiniteScroll from '@/hooks/useCursorInfiniteScroll';
 import {
@@ -16,7 +13,8 @@ import {
   SortType,
 } from '@/types/feedback.types';
 import { formatRelativeTime } from '@/utils/formatRelativeTime';
-import { memo, useCallback, useMemo } from 'react';
+import { useVirtualizer, VirtualItem } from '@tanstack/react-virtual';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useMyFeedbackData } from '../../hooks/useMyFeedbackData';
 import FeedbackStatusMessage from '../FeedbackStatusMessage/FeedbackStatusMessage';
 
@@ -53,6 +51,7 @@ export default memo(function UserFeedbackList({
     fetchMore,
     hasNext,
     loading,
+    isFetchingNextPage,
   } = useCursorInfiniteScroll<
     FeedbackType,
     'feedbacks',
@@ -64,10 +63,7 @@ export default memo(function UserFeedbackList({
     enabled: shouldUseInfiniteScroll,
   });
 
-  useGetFeedback({ fetchMore, hasNext, loading });
-
   const { myFeedbacks } = useMyFeedbackData();
-
   const { highlightedId } = useHighLighted();
 
   const displayFeedbacks = useMemo(
@@ -82,25 +78,97 @@ export default memo(function UserFeedbackList({
     [myLikeFeedbackIds]
   );
 
+  const myFeedbackIdSet = useMemo(
+    () => new Set(myFeedbacks.map((f) => f.feedbackId)),
+    [myFeedbacks]
+  );
+
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: hasNext ? feedbacks.length + 1 : feedbacks.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 200,
+    overscan: 3,
+  });
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  const lastVirtualIndex = virtualItems[virtualItems.length - 1]?.index;
+
+  useEffect(() => {
+    if (lastVirtualIndex === undefined) return;
+
+    if (
+      lastVirtualIndex >= displayFeedbacks.length - 1 &&
+      hasNext &&
+      !isFetchingNextPage &&
+      !loading
+    ) {
+      fetchMore();
+    }
+  }, [
+    lastVirtualIndex,
+    displayFeedbacks.length,
+    hasNext,
+    isFetchingNextPage,
+    loading,
+    fetchMore,
+  ]);
+
   return (
-    <>
-      <div id='user-feedback-list' tabIndex={-1} css={skipTarget}>
-        <FeedbackBoxList>
-          {displayFeedbacks.map((feedback: FeedbackType) => {
-            const isMyFeedback = myFeedbacks.some(
-              (myFeedback) => myFeedback.feedbackId === feedback.feedbackId
-            );
+    <div>
+      <div
+        id='user-feedback-list'
+        tabIndex={-1}
+        ref={parentRef}
+        style={{
+          height: 'calc(100vh - 200px)',
+          overflowY: 'auto',
+          contain: 'strict',
+        }}
+      >
+        <div
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: `${rowVirtualizer.getTotalSize()}px`,
+          }}
+        >
+          {virtualItems.map((virtualRow: VirtualItem) => {
+            const isLoaderRow = virtualRow.index > displayFeedbacks.length - 1;
+            const feedback = displayFeedbacks[virtualRow.index];
+
+            if (isLoaderRow) {
+              return (
+                <div
+                  key={`loading-${virtualRow.index}`}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: virtualRow.size,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <div>가져오는중</div>
+                </div>
+              );
+            }
+
+            if (!feedback) return null;
+
+            // console.log(feedbacks, virtualRow.index);
+
+            const isMyFeedback = myFeedbackIdSet.has(feedback.feedbackId);
             const postedAt = formatRelativeTime(feedback.postedAt ?? '');
+
             return (
-              <div key={feedback.feedbackId}>
-                <span className='srOnly'>
-                  {srFeedbackSummary({
-                    feedback,
-                    myFeedback: isMyFeedback,
-                    postedAt,
-                    isAdmin: false,
-                  })}
-                </span>
+              <VirtualFeedbackItem
+                key={virtualRow.key}
+                measureElement={rowVirtualizer.measureElement}
+                virtualRow={virtualRow}
+              >
                 <UserFeedbackBox
                   userName={feedback.userName}
                   type={feedback.status}
@@ -116,10 +184,15 @@ export default memo(function UserFeedbackList({
                   category={feedback.category}
                   imgUrl={feedback.imageUrl}
                 />
-              </div>
+              </VirtualFeedbackItem>
             );
           })}
-        </FeedbackBoxList>
+        </div>
+
+        {loading && displayFeedbacks.length === 0 && (
+          <FeedbackBoxSkeletonList count={2} />
+        )}
+
         {loading && <FeedbackBoxSkeletonList count={2} />}
         <FeedbackStatusMessage
           loading={loading}
@@ -127,8 +200,7 @@ export default memo(function UserFeedbackList({
           hasNext={hasNext}
           feedbackCount={displayFeedbacks.length}
         />
-        {hasNext && <div id='scroll-observer' style={{ minHeight: '1px' }} />}
       </div>
-    </>
+    </div>
   );
 });

--- a/frontend/src/domains/user/userDashboard/components/UserFeedbackList/UserFeedbackList.tsx
+++ b/frontend/src/domains/user/userDashboard/components/UserFeedbackList/UserFeedbackList.tsx
@@ -158,8 +158,6 @@ export default memo(function UserFeedbackList({
 
             if (!feedback) return null;
 
-            // console.log(feedbacks, virtualRow.index);
-
             const isMyFeedback = myFeedbackIdSet.has(feedback.feedbackId);
             const postedAt = formatRelativeTime(feedback.postedAt ?? '');
 

--- a/frontend/src/hooks/useCursorInfiniteScroll.ts
+++ b/frontend/src/hooks/useCursorInfiniteScroll.ts
@@ -52,6 +52,7 @@ export default function useCursorInfiniteScroll<
     fetchMore: query.fetchNextPage,
     hasNext: query.hasNextPage,
     loading: query.isFetching,
+    isFetchingNextPage: query.isFetchingNextPage,
   };
 }
 


### PR DESCRIPTION
## 😉 연관 이슈
#1020

## 🚀 작업 내용
- 만든것에 비해 머지가 늦었네요 ㅋㅋㅋ 허허
- 자세한 내용이 궁금하면 [노션](https://smooth-cirrus-894.notion.site/Virtualized-List-2b70cf49724a80b79d3ef20cddb7d178?source=copy_link) 봐주세용~

- 핵심 요약
  - 무한스크롤로 DOM 노드가 누적돼서 페이지 전환 시에 한번에 그려지고 사라지느라 CPU 사용률 100%까지 오름
  - 해결방법 : DOM 노드 문제를 해결해보자. 이를 위해선 가상화 리스트가 필요하다
  - 가상화리스트 : 부모 컨테이너의 viewPort 기준으로 자식 컨테이너(가상화 리스트)가 동적으로 높이 계산한다. 그래서 화면에 보여야 하는 컴포넌트의 개수를 계산해서 최대 약 20개 정도의 컴포넌트만 고정적으로 보이도록 만든 방법
  - 왜 성능이 좋나요 : absolute + transform:translate-Y를 사용해서 GPU만 사용하기 때문에 성능이 더 좋다. 

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 피드백 목록에 가상 스크롤 기능을 적용하여 대량 데이터 로딩 시 성능 향상
  * 무한 스크롤 로딩 상태 표시 기능 추가
  * 피드백 박스에 커스텀 스타일링 옵션 추가

* **Chores**
  * 가상 스크롤 라이브러리 의존성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->