### PR TITLE
[FE] feat: 관리자 -> 사용자 페이지 이동 로직 구현

### DIFF
--- a/frontend/src/components/Header/MoreMenu/MoreMenu.tsx
+++ b/frontend/src/components/Header/MoreMenu/MoreMenu.tsx
@@ -13,6 +13,7 @@ import QRModal from '@/domains/admin/components/QRModal/QRModal';
 import EditRoomModal from '@/domains/admin/EditRoomModal/EditRoomModal';
 import useDeleteOrganization from '@/domains/admin/EditRoomModal/hooks/useDeleteOrganization';
 import { useOrganizationId } from '@/domains/hooks/useOrganizationId';
+import { useNavigate } from 'react-router-dom';
 
 interface MoreMenuProps {
   closeMoreMenu: () => void;
@@ -24,6 +25,7 @@ export default function MoreMenu({ closeMoreMenu }: MoreMenuProps) {
   const { organizationId } = useOrganizationId();
   const { refetch, isFetching } = useDownloadFeedbacks(organizationId);
   const { showToast } = useToast();
+  const navigate = useNavigate();
 
   const handleRoomInfoEditClick = () => {
     openModal(<EditRoomModal onClose={closeModal} />);
@@ -64,7 +66,8 @@ export default function MoreMenu({ closeMoreMenu }: MoreMenuProps) {
   };
 
   const handleCustomerPageClick = () => {
-    window.location.href = `/${organizationId}/submit`;
+    navigate(`/${organizationId}/submit`);
+    closeMoreMenu();
   };
 
   const moreMenuList = [

--- a/frontend/src/components/Header/MoreMenu/MoreMenu.tsx
+++ b/frontend/src/components/Header/MoreMenu/MoreMenu.tsx
@@ -2,6 +2,7 @@ import ConfirmModal from '@/components/ConfirmModal/ConfirmModal';
 import useDownloadFeedbacks from '@/components/Header/hooks/useDownloadFeedbacks';
 import { moreMenuContainer } from '@/components/Header/MoreMenu/MoreMenu.styles';
 import MoreMenuItem from '@/components/Header/MoreMenuItem/MoreMenuItem';
+import ExternalIcon from '@/components/icons/External';
 import FileDownloadIcon from '@/components/icons/FileDownloadIcon';
 import ShareIcon from '@/components/icons/ShareIcon';
 import SmallSettingIcon from '@/components/icons/SmallSettingIcon';
@@ -62,6 +63,10 @@ export default function MoreMenu({ closeMoreMenu }: MoreMenuProps) {
     await refetch();
   };
 
+  const handleCustomerPageClick = () => {
+    window.location.href = `/${organizationId}/submit`;
+  };
+
   const moreMenuList = [
     {
       icon: <SmallSettingIcon />,
@@ -78,6 +83,11 @@ export default function MoreMenu({ closeMoreMenu }: MoreMenuProps) {
       icon: <FileDownloadIcon />,
       menu: '피드백 추출',
       onClick: downloadFeedbacksFile,
+    },
+    {
+      icon: <ExternalIcon />,
+      menu: '고객 페이지로 이동',
+      onClick: handleCustomerPageClick,
     },
   ];
 

--- a/frontend/src/components/icons/External.tsx
+++ b/frontend/src/components/icons/External.tsx
@@ -1,0 +1,19 @@
+export default function ExternalIcon() {
+  return (
+    <svg
+      width='16'
+      height='16'
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path d='M14 4H20M20 4V10M20 4L12 12' stroke='#33363F' strokeWidth='2' />
+      <path
+        d='M11 5H7C5.89543 5 5 5.89543 5 7V17C5 18.1046 5.89543 19 7 19H17C18.1046 19 19 18.1046 19 17V13'
+        stroke='#33363F'
+        strokeWidth='2'
+        strokeLinecap='round'
+      />
+    </svg>
+  );
+}

--- a/frontend/src/domains/user/userDashboard/components/UserDashboardHeader/UserDashboardHeader.tsx
+++ b/frontend/src/domains/user/userDashboard/components/UserDashboardHeader/UserDashboardHeader.tsx
@@ -28,7 +28,7 @@ export default function UserDashboardHeader() {
       </div>
       <GhostButton
         icon={<ProfileIcon />}
-        text='관리자 이용하기'
+        text='관리자 페이지로 이동'
         onClick={handleNavigateToOnboarding}
       />
     </div>


### PR DESCRIPTION
## 😉 연관 이슈
<img width="500" height="656" alt="CleanShot 2025-12-11 at 13 23 04@2x" src="https://github.com/user-attachments/assets/57111a13-2035-4e0b-b703-fe656e35a06f" />

<img width="500" height="994" alt="CleanShot 2025-12-11 at 13 23 14@2x" src="https://github.com/user-attachments/assets/12823ec7-c526-4ced-9867-0a26b6f08062" />

이런식으로 row만 하나 추가했습니다!

## 🚀 작업 내용

## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 더보기 메뉴에 고객 페이지로 바로 이동하는 항목이 추가되었습니다.
  * 외부 링크용 아이콘이 추가되었습니다.

* **개선사항**
  * 대시보드의 관리자 이동 버튼 텍스트가 '관리자 페이지로 이동'으로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->